### PR TITLE
feat(i18n): Phase 30.4 - Add language selector to Settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -109,7 +109,8 @@
       "Bash(node scripts/deploy-ftp.cjs:*)",
       "Bash(echo:*)",
       "Bash(npm install:*)",
-      "Bash(npm run build:deploy:staging:*)"
+      "Bash(npm run build:deploy:staging:*)",
+      "Bash(git branch:*)"
     ],
     "deny": [],
     "ask": []

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -53,6 +53,7 @@
     "medium": "Medium",
     "hard": "Hard",
     "mixed": "Mixed",
+    "language": "Language",
     "connection": "Connection to AI Provider",
     "about": "About",
     "helpFaq": "Help & FAQ",

--- a/public/locales/pt-PT.json
+++ b/public/locales/pt-PT.json
@@ -53,6 +53,7 @@
     "medium": "Médio",
     "hard": "Difícil",
     "mixed": "Misto",
+    "language": "Idioma",
     "connection": "Ligação ao Fornecedor de IA",
     "about": "Sobre",
     "helpFaq": "Ajuda e FAQ",

--- a/src/version.js
+++ b/src/version.js
@@ -1,4 +1,4 @@
 // Auto-generated - do not edit manually
-  export const APP_VERSION = '20251227.105';
-  export const BUILD_DATE = '2025-12-27T12:57:24.468Z';
+  export const APP_VERSION = '20251227.109';
+  export const BUILD_DATE = '2025-12-27T14:12:43.382Z';
   

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -3,7 +3,7 @@
   import { APP_VERSION, BUILD_DATE } from '../version.js';
   import { isConnected, disconnect } from '../services/auth-service.js';
   import { isFeatureEnabled } from '../core/features.js';
-  import { t } from '../core/i18n.js';
+  import { t, changeLanguage, getCurrentLanguage, SUPPORTED_LANGUAGES } from '../core/i18n.js';
 
   export default class SettingsView extends BaseView {
     constructor() {
@@ -68,6 +68,18 @@
         <option value="medium">${t('settings.medium')}</option>
         <option value="hard">${t('settings.hard')}</option>
         <option value="mixed" selected>${t('settings.mixed')}</option>
+      </select>
+    </label>
+
+    <!-- Language -->
+    <label class="flex flex-col">
+      <p class="text-base font-medium pb-2 text-text-light
+  dark:text-text-dark">${t('settings.language')}</p>
+      <select id="languageSelect" data-testid="language-select" class="form-select flex w-full rounded-lg
+  h-14 p-4 text-base font-normal leading-normal bg-card-light dark:bg-card-dark
+  border border-border-light dark:border-border-dark text-text-light
+  dark:text-text-dark focus:ring-2 focus:ring-primary focus:border-primary">
+        ${this.renderLanguageOptions()}
       </select>
     </label>
   </div>
@@ -174,6 +186,15 @@
       this.bindEvents();
     }
 
+    renderLanguageOptions() {
+      const currentLang = getCurrentLanguage();
+      return SUPPORTED_LANGUAGES.map(lang =>
+        `<option value="${lang.code}" ${lang.code === currentLang ? 'selected' : ''}>
+          ${lang.flag} ${lang.name}
+        </option>`
+      ).join('');
+    }
+
     loadSettings() {
       const settings = getSettings();
 
@@ -181,10 +202,12 @@
       const gradeSelect = this.querySelector('#defaultGradeLevel');
       const questionsSelect = this.querySelector('#questionsPerQuiz');
       const difficultySelect = this.querySelector('#difficulty');
+      const languageSelect = this.querySelector('#languageSelect');
 
       if (gradeSelect) gradeSelect.value = settings.defaultGradeLevel;
-      if (questionsSelect) questionsSelect.value = settings.questionsPerQuiz;       
+      if (questionsSelect) questionsSelect.value = settings.questionsPerQuiz;
       if (difficultySelect) difficultySelect.value = settings.difficulty;
+      if (languageSelect) languageSelect.value = getCurrentLanguage();
     }
 
       async loadAccountStatus() {
@@ -249,6 +272,7 @@
       const gradeSelect = this.querySelector('#defaultGradeLevel');
       const questionsSelect = this.querySelector('#questionsPerQuiz');
       const difficultySelect = this.querySelector('#difficulty');
+      const languageSelect = this.querySelector('#languageSelect');
 
       this.addEventListener(gradeSelect, 'change', (e) => {
         saveSetting('defaultGradeLevel', e.target.value);
@@ -260,6 +284,13 @@
 
       this.addEventListener(difficultySelect, 'change', (e) => {
         saveSetting('difficulty', e.target.value);
+      });
+
+      this.addEventListener(languageSelect, 'change', async (e) => {
+        const newLang = e.target.value;
+        await changeLanguage(newLang);
+        // Re-render to apply new language
+        await this.render();
       });
     }
 


### PR DESCRIPTION
## Summary

- Add language dropdown to Settings page Preferences section
- Show supported languages with country flags (🇬🇧 🇵🇹 🇪🇸 🇫🇷 🇩🇪)
- Re-render view immediately on language change
- Persist language preference to localStorage

## Changes

**SettingsView.js:**
- Import `changeLanguage`, `getCurrentLanguage`, `SUPPORTED_LANGUAGES` from i18n
- Add `renderLanguageOptions()` helper method
- Add language select with `data-testid="language-select"`
- Handle language change with async re-render

**Locales:**
- Add `settings.language` key to en.json and pt-PT.json

## Test plan

- [x] All 202 unit tests pass
- [x] All 36 E2E tests pass
- [ ] Manual test: Change language in Settings, verify UI updates immediately
- [ ] Manual test: Refresh page, verify language preference persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)