### PR TITLE
fix(test): use class-based dark mode in E2E test

### DIFF
--- a/docs/issues/100.md
+++ b/docs/issues/100.md
@@ -1,0 +1,55 @@
+# Issue #100: E2E Test - Dark mode brightness check fails
+
+**Status:** In Progress
+**Branch:** `fix/issue-100-dark-mode-test`
+**Created:** 2026-01-09
+
+---
+
+## Problem Statement
+
+The E2E test `should display quiz correctly in dark mode` consistently fails in CI with:
+```
+Error: expect(received).toBeLessThan(expected)
+Expected: < 128
+Received:   249
+```
+
+The test expects a dark background but gets a light one.
+
+## Root Cause Analysis
+
+The test uses `page.emulateMedia({ colorScheme: 'dark' })` to enable dark mode, but the app uses **Tailwind's class-based dark mode**, not CSS media queries.
+
+- `emulateMedia` only affects `prefers-color-scheme` media query
+- The app toggles dark mode by adding/removing the `dark` class on `<html>`
+- The app doesn't respond to `prefers-color-scheme`
+
+**Code Reference:**
+- `src/services/theme-manager.js:44-52` - Dark mode is applied via `root.classList.add('dark')`
+
+## Solution
+
+Replace `page.emulateMedia({ colorScheme: 'dark' })` with direct class manipulation:
+```javascript
+await page.evaluate(() => {
+  document.documentElement.classList.add('dark');
+});
+```
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `tests/e2e/app.spec.js` | Line 633: Replace emulateMedia with classList.add('dark') |
+
+## Testing Plan
+
+- [ ] Run failing test to confirm it fails
+- [ ] Apply fix
+- [ ] Run test to confirm it passes
+- [ ] Run full E2E suite
+
+---
+
+**Last Updated:** 2026-01-09

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -629,10 +629,13 @@ test.describe('Saberloop E2E Tests', () => {
     // Set up auth state
     await setupAuthenticatedState(page);
 
-    // Enable dark mode via media query emulation
-    await page.emulateMedia({ colorScheme: 'dark' });
-
     await page.goto('/#/topic-input');
+
+    // Enable dark mode via Tailwind's class-based approach (not media query)
+    // The app uses classList.add('dark') on <html>, not prefers-color-scheme
+    await page.evaluate(() => {
+      document.documentElement.classList.add('dark');
+    });
     await page.fill('#topicInput', 'Science');
     await page.click('#generateBtn');
 


### PR DESCRIPTION
## Summary

- Fixes E2E test that was failing in CI due to incorrect dark mode approach
- The test used `emulateMedia({ colorScheme: 'dark' })` but the app uses Tailwind's class-based dark mode

## Root Cause

| What the test did | What the app does |
|-------------------|-------------------|
| `page.emulateMedia({ colorScheme: 'dark' })` | `document.documentElement.classList.add('dark')` |
| Affects `prefers-color-scheme` media query | Tailwind class-based theming |

## Fix

```javascript
// Before
await page.emulateMedia({ colorScheme: 'dark' });

// After
await page.evaluate(() => {
  document.documentElement.classList.add('dark');
});
```

## Test plan

- [x] Confirmed test fails before fix (Expected < 128, Received 249)
- [x] Confirmed test passes after fix

Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)