### PR TITLE
docs(issues): create plan for issue 122 party join onboarding bypass

### DIFF
--- a/docs/issues/122.md
+++ b/docs/issues/122.md
@@ -1,0 +1,187 @@
+# Issue #122: Party join links redirect new users to onboarding instead of join screen
+
+**GitHub:** https://github.com/vitorsilva/saberloop/issues/122
+**Status:** Plan Ready
+**Created:** 2026-01-16
+**Labels:** bug, party-mode, ux
+**Branch:** `fix/issue-122-party-join-onboarding-bypass`
+
+---
+
+## Problem
+
+When a new user clicks a party join link (e.g., `https://saberloop.com/app/#/party/join/5MD343`) and it's their first time accessing the app, they get redirected to the onboarding/welcome screen instead of going directly to the "Join Party" screen.
+
+**User Impact:**
+- Confusing experience - user clicked a specific link but landed somewhere unexpected
+- Delays adoption - user must complete onboarding before joining the party
+- Social friction - friends waiting in the party lobby while new user figures out the app
+- Potential drop-off - new users might give up before completing onboarding
+
+**Expected Behavior:**
+New users with a party join link should go directly to the "Join Party" screen with the room code pre-filled, bypassing the onboarding flow.
+
+---
+
+## Root Cause Analysis
+
+The issue is a **timing/order problem** in `src/main.js`:
+
+1. **Router initializes first** (line 96): `router.init()` processes `#/party/join/CODE` and renders JoinPartyView
+2. **Onboarding check runs after** (lines 105-110): Checks if user needs onboarding and redirects to `#/welcome`
+3. **Result**: The welcome redirect overwrites the party join view
+
+```javascript
+// src/main.js lines 105-110
+const showWelcome = await shouldShowWelcome();
+if (showWelcome) {
+  window.location.hash = '#/welcome';  // Overwrites party join URL
+}
+```
+
+The router correctly handles party URLs (`src/core/router.js` lines 42-47), but the subsequent onboarding redirect in `main.js` takes precedence.
+
+---
+
+## Proposed Solution
+
+**Skip onboarding redirect for party URLs.** Check if the current URL is a party-related route before redirecting to welcome.
+
+### Implementation
+
+Modify `src/main.js` to check for party join URL before the onboarding redirect:
+
+```javascript
+// Check if current URL is a party join route (should bypass onboarding)
+const hash = window.location.hash.slice(1) || '/';
+const isPartyJoinRoute = hash.startsWith('/party/join/');
+
+// Redirect to welcome if needed (unless joining a party via shared link)
+const showWelcome = await shouldShowWelcome();
+if (showWelcome && !isPartyJoinRoute) {
+  window.location.hash = '#/welcome';
+}
+```
+
+### Why Only `/party/join/`
+
+- `/party/join/CODE` is the entry point for shared links - new users arrive here
+- `/party/lobby/`, `/party/quiz/`, `/party/results/` are internal navigation after joining
+- Users accessing lobby/quiz/results directly would have other guards (session validation)
+- More precise scope = fewer edge cases
+
+### Alternative Considered
+
+**Store party URL and restore after onboarding**: More complex, requires user to complete onboarding first which defeats the purpose of reducing friction.
+
+---
+
+## Acceptance Criteria
+
+- [ ] New users clicking party join links go directly to Join Party screen
+- [ ] Room code is pre-filled from the URL
+- [ ] Existing users (who completed onboarding) are unaffected
+- [ ] Direct navigation to `/welcome` still works for new users
+- [ ] After party session, normal app navigation works
+- [ ] Only `/party/join/` bypasses onboarding (other party routes do not)
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/main.js` | Add party route check before onboarding redirect |
+
+---
+
+## Testing Plan
+
+### Automated Testing (E2E)
+
+Create E2E test to verify party join link behavior for new users:
+
+```javascript
+// tests/e2e/party-join-onboarding.spec.js
+test('new user with party join link bypasses onboarding', async ({ page, context }) => {
+  // Clear all storage to simulate new user
+  await context.clearCookies();
+  await page.goto('about:blank');
+  await page.evaluate(() => {
+    localStorage.clear();
+    indexedDB.deleteDatabase('saberloop');
+  });
+
+  // Navigate directly to party join URL
+  await page.goto('/#/party/join/TEST123');
+
+  // Should be on join party screen, NOT welcome screen
+  await expect(page.locator('[data-testid="join-party-view"]')).toBeVisible();
+  await expect(page.locator('[data-testid="welcome-view"]')).not.toBeVisible();
+
+  // Room code should be pre-filled
+  await expect(page.locator('[data-testid="room-code-input"]')).toHaveValue('TEST123');
+});
+```
+
+### Manual Testing Checklist
+
+- [ ] New user + party join link → lands on Join Party screen
+- [ ] New user + party join link → room code is pre-filled
+- [ ] New user + direct app access → sees onboarding as normal
+- [ ] Existing user + party join link → lands on Join Party screen
+- [ ] After party ends, new user can navigate app normally
+
+### Verification Steps
+
+```bash
+# Run E2E tests
+npm run test:e2e
+
+# Manual: Open incognito/private window
+# Navigate to: https://saberloop.com/app/#/party/join/TESTCODE
+# Verify: Join Party screen appears (not Welcome screen)
+```
+
+---
+
+## Pre-Implementation Checklist
+
+- [x] Root cause identified
+- [x] Solution designed
+- [x] Testing plan defined
+- [ ] Branch created
+- [ ] Plan validated by user
+
+---
+
+## Implementation Notes
+
+*To be filled during implementation.*
+
+---
+
+## Branch & Commit Strategy
+
+### Branch
+
+```
+fix/issue-122-party-join-onboarding-bypass
+```
+
+### Commit Plan
+
+| Order | Commit Message |
+|-------|----------------|
+| 1 | `test(e2e): add failing test for party join onboarding bypass` |
+| 2 | `fix(onboarding): allow party routes to bypass welcome redirect` |
+| 3 | `docs(issues): update plan for issue 122` |
+
+---
+
+## References
+
+- Router party handling: `src/core/router.js:42-47`
+- Onboarding redirect: `src/main.js:105-110`
+- Onboarding logic: `src/features/onboarding.js`
+- JoinPartyView: `src/views/JoinPartyView.js`


### PR DESCRIPTION
New users clicking party join links get redirected to onboarding instead of the join party screen. Plan documents root cause (timing issue in main.js) and solution (check for party routes before onboarding redirect).