### PR TITLE
docs(issues): create plan for issue 130 delete individual quiz

### DIFF
--- a/docs/issues/130.md
+++ b/docs/issues/130.md
@@ -1,0 +1,398 @@
+# Issue #130: Add ability to delete individual quizzes from history
+
+**GitHub:** https://github.com/vitorsilva/saberloop/issues/130
+**Status:** Plan Ready
+**Created:** 2026-01-16
+**Labels:** enhancement, ux
+**Branch:** `feature/issue-130-delete-individual-quiz`
+
+---
+
+## Problem
+
+Users can delete all their data via Settings, but there's no way to delete a single quiz from their history. This is a common need when users want to:
+- Remove a quiz they created by mistake
+- Clean up duplicate quizzes (visible in the screenshot - "Plaquetas baixas no sangue" appears twice)
+- Delete a quiz without losing all their progress
+
+**Current State:**
+- Quiz history shows all past quizzes with share and replay buttons
+- Settings has "Delete All Data" option (bulk delete)
+- No way to remove individual quizzes
+
+**Desired State:**
+- Add a delete button to each quiz card in the history view
+- Show confirmation before deleting
+- Remove the quiz from IndexedDB
+
+---
+
+## Root Cause Analysis
+
+The feature simply doesn't exist yet. The database layer (`db.js`) has bulk delete operations but no single-record delete function for sessions:
+
+| Function | Exists | Purpose |
+|----------|--------|---------|
+| `clearAllUserData()` | Yes | Delete all non-sample sessions |
+| `deleteSampleSessions()` | Yes | Delete sample quizzes only |
+| `deleteSession(id)` | **No** | Delete single quiz by ID |
+
+---
+
+## Proposed Solution
+
+Add a delete button to each quiz card in the history view, with confirmation modal.
+
+### UI Design
+
+Add a delete (trash) icon button next to the existing share button on each quiz card:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 🎓  Plaquetas baixas no sangue     🔗  🗑️   0/5 > │
+│     semana passada                                  │
+└─────────────────────────────────────────────────────┘
+                                      ↑    ↑
+                                   share delete
+```
+
+- Delete button: Red trash icon, appears on hover or always visible on mobile
+- Clicking shows confirmation modal before deleting
+- After deletion, quiz card is removed from the list with smooth animation
+
+### Implementation
+
+**1. Database Layer** (`src/core/db.js`)
+
+Add `deleteSession(id)` function:
+
+```javascript
+/**
+ * Delete a single quiz session by ID
+ * @param {number} id - Session ID to delete
+ * @returns {Promise<void>}
+ */
+export async function deleteSession(id) {
+  const db = await getDB();
+  return db.delete('sessions', id);
+}
+```
+
+**2. Service Layer** (`src/services/quiz-service.js`)
+
+Add wrapper function with validation:
+
+```javascript
+/**
+ * Delete a quiz from history
+ * @param {number} id - Quiz session ID
+ * @returns {Promise<boolean>} True if deleted
+ */
+export async function deleteQuiz(id) {
+  const session = await getSession(id);
+  if (!session) {
+    return false;
+  }
+  await deleteSession(id);
+  return true;
+}
+```
+
+**3. UI Layer** (`src/views/TopicsView.js`)
+
+Add delete button to `renderQuizItem()` method (around line 165):
+
+```javascript
+<button class="delete-quiz-btn flex size-10 items-center justify-center rounded-full
+  hover:bg-red-500/10 text-red-500 transition-colors"
+  data-session-id="${session.id}"
+  aria-label="${t('history.deleteQuiz')}">
+  <span class="material-symbols-outlined text-xl">delete</span>
+</button>
+```
+
+Add click handler in `attachListeners()`:
+
+```javascript
+this.container.querySelectorAll('.delete-quiz-btn').forEach(btn => {
+  this.addEventListener(btn, 'click', async (e) => {
+    e.stopPropagation(); // Prevent card click (replay)
+    const sessionId = parseInt(btn.dataset.sessionId, 10);
+    await this.handleDeleteQuiz(sessionId);
+  });
+});
+```
+
+**4. Confirmation Modal** (`src/components/DeleteQuizModal.js`)
+
+Create new modal following the pattern from `DeleteDataModal.js`:
+
+```javascript
+import { t } from '../core/i18n.js';
+
+/**
+ * Show a confirmation modal for deleting a single quiz
+ * @param {string} topic - Quiz topic name to display
+ * @returns {Promise<boolean>} true if confirmed, false if cancelled
+ */
+export function showDeleteQuizModal(topic) {
+  return new Promise((resolve) => {
+    const backdrop = document.createElement('div');
+    backdrop.id = 'deleteQuizModal';
+    backdrop.className = 'fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4';
+
+    backdrop.innerHTML = `
+      <div class="bg-background-light dark:bg-background-dark rounded-2xl p-6 max-w-sm w-full shadow-xl"
+           data-testid="delete-quiz-modal">
+        <div class="flex flex-col items-center text-center">
+          <div class="flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10 mb-4">
+            <span class="material-symbols-outlined text-3xl text-red-500">delete</span>
+          </div>
+
+          <h2 class="text-xl font-bold text-text-light dark:text-text-dark mb-2">
+            ${t('history.deleteQuizConfirm')}
+          </h2>
+
+          <p class="text-subtext-light dark:text-subtext-dark text-sm mb-6">
+            ${t('history.deleteQuizDescription', { topic })}
+          </p>
+
+          <button id="cancelDeleteQuizBtn"
+            class="w-full h-12 rounded-xl bg-card-light dark:bg-card-dark text-text-light dark:text-text-dark font-medium hover:bg-primary/10 transition-colors mb-3">
+            ${t('common.cancel')}
+          </button>
+
+          <button id="confirmDeleteQuizBtn" data-testid="confirm-delete-btn"
+            class="w-full h-12 rounded-xl bg-red-500 hover:bg-red-600 text-white font-bold transition-colors flex items-center justify-center gap-2">
+            <span class="material-symbols-outlined">delete</span>
+            ${t('history.deleteQuiz')}
+          </button>
+        </div>
+      </div>
+    `;
+
+    document.body.appendChild(backdrop);
+
+    const cancelBtn = backdrop.querySelector('#cancelDeleteQuizBtn');
+    const confirmBtn = backdrop.querySelector('#confirmDeleteQuizBtn');
+
+    // Cancel button
+    cancelBtn.addEventListener('click', () => {
+      backdrop.remove();
+      resolve(false);
+    });
+
+    // Confirm button
+    confirmBtn.addEventListener('click', () => {
+      backdrop.remove();
+      resolve(true);
+    });
+
+    // Backdrop click to close
+    backdrop.addEventListener('click', (e) => {
+      if (e.target === backdrop) {
+        backdrop.remove();
+        resolve(false);
+      }
+    });
+
+    // Escape key to close
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        backdrop.remove();
+        document.removeEventListener('keydown', handleEscape);
+        resolve(false);
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+  });
+}
+```
+
+**Key modal features (following existing patterns):**
+- Promise-based API returning boolean
+- Backdrop click to dismiss
+- Escape key to dismiss
+- Cancel button (secondary) above Confirm button (danger/red)
+- Uses `data-testid` attributes for E2E testing
+- Follows existing Tailwind styling conventions
+
+**5. i18n Strings**
+
+Add to translation files:
+
+```javascript
+// English
+"history.deleteQuiz": "Delete quiz",
+"history.deleteQuizConfirm": "Delete this quiz?",
+"history.deleteQuizDescription": "This will permanently remove \"{topic}\" from your history.",
+"history.quizDeleted": "Quiz deleted"
+
+// Portuguese
+"history.deleteQuiz": "Apagar quiz",
+"history.deleteQuizConfirm": "Apagar este quiz?",
+"history.deleteQuizDescription": "Isto vai remover permanentemente \"{topic}\" do teu histórico.",
+"history.quizDeleted": "Quiz apagado"
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Delete button visible on each quiz card in history (TopicsView)
+- [ ] Clicking delete shows confirmation modal with quiz topic name
+- [ ] Confirming deletion removes quiz from IndexedDB
+- [ ] Quiz card is removed from the list after deletion
+- [ ] Success toast shown after deletion
+- [ ] Sample quizzes can also be deleted individually
+- [ ] Delete button works on mobile (touch-friendly size)
+- [ ] i18n: All strings translated (PT, EN at minimum)
+
+### Out of Scope (for this issue)
+
+- Delete from HomeView recent quizzes (can be added later)
+- Bulk select/delete multiple quizzes
+- Undo deletion
+- Swipe-to-delete gesture
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/core/db.js` | Add `deleteSession(id)` function |
+| `src/services/quiz-service.js` | Add `deleteQuiz(id)` wrapper |
+| `src/views/TopicsView.js` | Add delete button and handler |
+| `src/components/DeleteQuizModal.js` | New: Confirmation modal (or adapt existing) |
+| `src/i18n/locales/en.json` | Add delete-related strings |
+| `src/i18n/locales/pt.json` | Add delete-related strings |
+
+---
+
+## Testing Plan
+
+### Unit Tests
+
+```javascript
+// db.test.js
+describe('deleteSession', () => {
+  it('should delete a session by ID', async () => {
+    const session = await saveSession({ topic: 'Test', ... });
+    await deleteSession(session.id);
+    const result = await getSession(session.id);
+    expect(result).toBeUndefined();
+  });
+
+  it('should not throw if session does not exist', async () => {
+    await expect(deleteSession(99999)).resolves.not.toThrow();
+  });
+});
+```
+
+### E2E Tests
+
+```javascript
+// tests/e2e/quiz-delete.spec.js
+test('user can delete individual quiz from history', async ({ page }) => {
+  // Setup: ensure there's at least one quiz in history
+  await page.goto('/#/history');
+
+  // Get initial quiz count
+  const initialCount = await page.locator('.quiz-item').count();
+  expect(initialCount).toBeGreaterThan(0);
+
+  // Click delete on first quiz
+  await page.locator('.quiz-item').first().locator('.delete-quiz-btn').click();
+
+  // Confirm deletion
+  await expect(page.locator('[data-testid="delete-quiz-modal"]')).toBeVisible();
+  await page.locator('[data-testid="confirm-delete-btn"]').click();
+
+  // Verify quiz is removed
+  await expect(page.locator('.quiz-item')).toHaveCount(initialCount - 1);
+
+  // Verify success toast
+  await expect(page.locator('.toast')).toContainText(/deleted|apagado/i);
+});
+```
+
+### Manual Testing Checklist
+
+- [ ] Delete button appears on quiz cards
+- [ ] Delete button is clickable (doesn't trigger replay)
+- [ ] Confirmation modal shows quiz topic
+- [ ] Cancel closes modal without deleting
+- [ ] Confirm deletes quiz and updates list
+- [ ] Toast confirms deletion
+- [ ] Works on mobile/touch devices
+- [ ] Works for sample quizzes
+
+### Screenshots
+
+Capture before/after screenshots and save to `docs/issues/`:
+
+| Screenshot | Filename | Description |
+|------------|----------|-------------|
+| Before | `130-before.png` | History view without delete button |
+| After | `130-after.png` | History view with delete button visible |
+| Modal | `130-modal.png` | Confirmation modal when deleting |
+
+---
+
+## Pre-Implementation Checklist
+
+- [x] Root cause identified (feature doesn't exist)
+- [x] Solution designed
+- [x] Testing plan defined
+- [ ] Branch created
+- [ ] Plan validated by user
+
+---
+
+## Implementation Notes
+
+*To be filled during implementation.*
+
+---
+
+## Branch & Commit Strategy
+
+### Branch
+
+```
+feature/issue-130-delete-individual-quiz
+```
+
+### Commit Plan
+
+| Order | Commit Message |
+|-------|----------------|
+| 1 | `feat(db): add deleteSession function for single quiz deletion` |
+| 2 | `feat(quiz-service): add deleteQuiz wrapper with validation` |
+| 3 | `feat(i18n): add quiz deletion translation strings` |
+| 4 | `feat(ui): add delete button to quiz cards in history view` |
+| 5 | `feat(modal): add confirmation modal for quiz deletion` |
+| 6 | `test: add unit and E2E tests for quiz deletion` |
+| 7 | `docs(issues): update plan for issue 130` |
+
+---
+
+## References
+
+### Code
+- Quiz history view: `src/views/TopicsView.js:104-178`
+- Database operations: `src/core/db.js`
+- Quiz service: `src/services/quiz-service.js`
+
+### Existing Modal Patterns (use as templates)
+- `src/components/DeleteDataModal.js` - **Primary template**: Centered modal, Promise-based, confirmation pattern
+- `src/components/ShareQuizModal.js` - Bottom sheet pattern, toast notifications, escape/backdrop handling
+- `src/components/ConnectModal.js` - Connection flow modal
+- `src/components/ExplanationModal.js` - Content display modal
+
+### Developer Guides
+- [Unit Testing Guide](../developer-guide/UNIT_TESTING.md) - Writing tests for db.js and quiz-service.js
+- [E2E Testing Guide](../developer-guide/E2E_TESTING.md) - Writing Playwright tests for UI flows
+- [I18N Guide](../developer-guide/I18N.md) - Adding translation strings for new UI text
+- [Troubleshooting](../developer-guide/TROUBLESHOOTING.md) - Common issues and solutions


### PR DESCRIPTION
Add ability to delete individual quizzes from history view:
- Delete button on each quiz card (next to share button)
- Confirmation modal following DeleteDataModal.js pattern
- New deleteSession() function in db.js
- i18n strings for PT/EN
- Screenshots section for before/after documentation