### PR TITLE
feat(llm): Phase 2 - Frontend Provider Router

### DIFF
--- a/docs/learning/epic10_hygiene/FLAG_MULTI_PROVIDER_LLM.md
+++ b/docs/learning/epic10_hygiene/FLAG_MULTI_PROVIDER_LLM.md
@@ -1,0 +1,89 @@
+# Flag: MULTI_PROVIDER_LLM
+
+**Status:** Active - In Development
+**Review After:** Epic 11 Phase 5 (Polish) completion
+**Risk Level:** N/A (new feature, not removing)
+
+---
+
+## Flag Details
+
+| Property | Value |
+|----------|-------|
+| Flag Name | `MULTI_PROVIDER_LLM` |
+| Current Phase | `DISABLED` |
+| Description | Allow users to configure and use multiple LLM providers |
+| Usages | TBD (Phase 2-4 will add usages) |
+| Files Affected | TBD |
+
+---
+
+## Purpose
+
+This flag controls the gradual rollout of multi-provider LLM support (Epic 11). When enabled, users can:
+- Configure API keys for OpenAI, Anthropic, Google AI, xAI
+- Select active provider and model in Settings
+- Use direct provider APIs instead of OpenRouter
+
+---
+
+## Rollout Strategy
+
+| Epic Phase | Production | Staging |
+|------------|------------|---------|
+| Phase 2 (Router) | `DISABLED` | `DISABLED` |
+| Phase 3 (Keys) | `DISABLED` | `DISABLED` |
+| Phase 4 (Settings UI) | `DISABLED` | `SETTINGS_ONLY` |
+| Phase 5 (Polish) - during | `DISABLED` | `ENABLED` |
+| Phase 5 (Polish) - final | `ENABLED` | `ENABLED` |
+
+---
+
+## Current Usages
+
+### Phase 2 (will add)
+
+- `src/api/provider-router.js` - Route LLM calls based on active provider
+- `src/api/api.real.js` - Use provider router for quiz/explanation generation
+
+### Phase 3 (will add)
+
+- `src/services/provider-settings-service.js` - API key storage/retrieval
+
+### Phase 4 (will add)
+
+- `src/views/SettingsView.js` - Provider configuration UI
+- Settings panel for adding/removing API keys
+
+---
+
+## Removal Criteria
+
+Remove this flag when ALL conditions are met:
+
+- [ ] Epic 11 is complete and stable in production
+- [ ] Multi-provider feature has been active for at least 2 weeks
+- [ ] No rollback has been needed
+- [ ] Telemetry shows stable usage across all providers
+- [ ] Decision made that feature is permanent (no A/B testing needed)
+
+---
+
+## Rollback Plan
+
+If issues in production:
+1. Set flag to `DISABLED` in `features.js`
+2. Rebuild and redeploy
+3. Existing OpenRouter behavior is preserved
+4. User settings remain in IndexedDB for future re-enablement
+
+---
+
+## Related
+
+- [Epic 11: Multi-Provider LLM Support](../../epic11_llm_support/EPIC11_LLM_SUPPORT_PLAN.md)
+- [Phase 2: Frontend Provider Router](../../epic11_llm_support/PHASE2_FRONTEND_ROUTER.md)
+
+---
+
+**Last Updated:** 2026-01-22

--- a/docs/learning/epic10_hygiene/TASK_MSW_INTEGRATION_TESTING.md
+++ b/docs/learning/epic10_hygiene/TASK_MSW_INTEGRATION_TESTING.md
@@ -1,0 +1,499 @@
+# Task: MSW + Playwright API Integration Testing
+
+**Epic:** 10 - Project Hygiene
+**Status:** Planned
+**Priority:** Low (Enhancement)
+**Created:** January 22, 2026
+**Context:** Identified during Epic 11 Phase 2 implementation
+
+---
+
+## Problem Statement
+
+Current testing has a gap between unit tests (everything mocked) and E2E tests (full UI):
+
+```
+Unit Tests              ???                 E2E Tests
+(all mocked)        (the gap)              (full UI)
+     │                  │                      │
+     ▼                  ▼                      ▼
+┌─────────┐       ┌───────────┐         ┌──────────┐
+│ router  │       │  router   │         │  User    │
+│ (mock   │       │     +     │         │  clicks  │
+│  fetch) │       │  backend  │         │   UI     │
+└─────────┘       └───────────┘         └──────────┘
+```
+
+**The gap:** We don't have tests that:
+- Call `completion()` from provider-router with realistic behavior
+- Test frontend code against realistic API responses
+- Verify error handling paths with controlled failures
+- Run fast without hitting real APIs or requiring backend
+
+---
+
+## Proposed Solution
+
+Two complementary approaches:
+
+### 1. MSW (Mock Service Worker) for Vitest Integration Tests
+
+Test frontend modules with realistic network behavior, mocked at the fetch level.
+
+**Why MSW:**
+- Intercepts at network level - code runs exactly as production
+- Works in Node (Vitest) and browser
+- No special test builds needed
+- Industry standard in 2025/2026
+
+### 2. Playwright API Tests for Backend Contract
+
+Test backend endpoints directly without browser, verify response shapes.
+
+**Why Playwright API:**
+- Already using Playwright for E2E
+- `request` context for pure API testing
+- Can run against local Docker or staging
+- We already have `llm-proxy.spec.js` as starting point
+
+---
+
+## Implementation Plan
+
+### Phase A: Add MSW to Vitest (Frontend Integration)
+
+#### A.1 Install MSW
+
+```bash
+npm install --save-dev msw
+```
+
+#### A.2 Create MSW Handlers
+
+**File:** `src/mocks/handlers.js`
+
+```javascript
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  // LLM Proxy - Success response
+  http.post('https://saberloop.com/llm/completion.php', async ({ request }) => {
+    const body = await request.json();
+
+    // Simulate different providers
+    const responses = {
+      openai: {
+        text: 'Mock response from OpenAI',
+        model: body.model || 'gpt-4o-mini',
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 }
+      },
+      anthropic: {
+        text: 'Mock response from Anthropic',
+        model: body.model || 'claude-3-5-sonnet-20241022',
+        usage: { prompt_tokens: 15, completion_tokens: 25, total_tokens: 40 }
+      },
+      google: {
+        text: 'Mock response from Google',
+        model: body.model || 'gemini-2.0-flash',
+        usage: { prompt_tokens: 12, completion_tokens: 18, total_tokens: 30 }
+      },
+      xai: {
+        text: 'Mock response from xAI',
+        model: body.model || 'grok-2-latest',
+        usage: { prompt_tokens: 8, completion_tokens: 22, total_tokens: 30 }
+      }
+    };
+
+    return HttpResponse.json(responses[body.provider] || responses.openai);
+  }),
+
+  // LLM Proxy - Error responses
+  http.post('https://saberloop.com/llm/completion.php', async ({ request }) => {
+    const body = await request.json();
+
+    // Simulate invalid API key
+    if (body.api_key === 'invalid-key') {
+      return HttpResponse.json(
+        { error: 'Invalid API key' },
+        { status: 401 }
+      );
+    }
+
+    // Simulate rate limit
+    if (body.api_key === 'rate-limited-key') {
+      return HttpResponse.json(
+        { error: 'Rate limit exceeded' },
+        { status: 429 }
+      );
+    }
+  }),
+
+  // OpenRouter direct (CORS supported)
+  http.post('https://openrouter.ai/api/v1/chat/completions', async ({ request }) => {
+    return HttpResponse.json({
+      choices: [{ message: { content: 'Mock OpenRouter response' } }],
+      model: 'anthropic/claude-3.5-sonnet',
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 }
+    });
+  }),
+
+  // OpenRouter key validation
+  http.get('https://openrouter.ai/api/v1/auth/key', async ({ request }) => {
+    const auth = request.headers.get('Authorization');
+    if (auth?.includes('valid')) {
+      return HttpResponse.json({ valid: true });
+    }
+    return HttpResponse.json({ error: 'Invalid key' }, { status: 401 });
+  }),
+];
+```
+
+#### A.3 Create MSW Server Setup
+
+**File:** `src/mocks/server.js`
+
+```javascript
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers.js';
+
+export const server = setupServer(...handlers);
+```
+
+#### A.4 Configure Vitest Setup
+
+**File:** `vitest.setup.js` (update)
+
+```javascript
+import { beforeAll, afterEach, afterAll } from 'vitest';
+import { server } from './src/mocks/server.js';
+
+// Start MSW server before all tests
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+
+// Reset handlers after each test
+afterEach(() => server.resetHandlers());
+
+// Clean up after all tests
+afterAll(() => server.close());
+```
+
+#### A.5 Create Integration Tests
+
+**File:** `src/api/provider-router.integration.test.js`
+
+```javascript
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../mocks/server.js';
+import { completion } from './provider-router.js';
+import { setActiveProvider, setActiveModel, setProviderKey } from '../services/provider-settings-service.js';
+
+describe('Provider Router Integration (MSW)', () => {
+  describe('OpenRouter (direct CORS)', () => {
+    it('should call OpenRouter directly when selected', async () => {
+      await setActiveProvider('openrouter');
+      await setActiveModel('anthropic/claude-3.5-sonnet');
+      await setProviderKey('openrouter', 'sk-or-valid-key');
+
+      const result = await completion('Hello', { maxTokens: 100 });
+
+      expect(result.text).toBe('Mock OpenRouter response');
+      expect(result.model).toBe('anthropic/claude-3.5-sonnet');
+    });
+  });
+
+  describe('OpenAI (via proxy)', () => {
+    it('should route through proxy for non-CORS providers', async () => {
+      await setActiveProvider('openai');
+      await setActiveModel('gpt-4o-mini');
+      await setProviderKey('openai', 'sk-valid-openai-key');
+
+      const result = await completion('Hello', { maxTokens: 100 });
+
+      expect(result.text).toBe('Mock response from OpenAI');
+      expect(result.usage.total_tokens).toBe(30);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle invalid API key error', async () => {
+      await setActiveProvider('openai');
+      await setProviderKey('openai', 'invalid-key');
+
+      await expect(completion('Hello', {}))
+        .rejects.toThrow(/Invalid API key/);
+    });
+
+    it('should handle rate limit error', async () => {
+      await setActiveProvider('openai');
+      await setProviderKey('openai', 'rate-limited-key');
+
+      await expect(completion('Hello', {}))
+        .rejects.toThrow(/Rate limit/);
+    });
+
+    it('should handle network failure', async () => {
+      // Override handler for this test
+      server.use(
+        http.post('https://saberloop.com/llm/completion.php', () => {
+          return HttpResponse.error();
+        })
+      );
+
+      await setActiveProvider('openai');
+      await setProviderKey('openai', 'sk-valid');
+
+      await expect(completion('Hello', {}))
+        .rejects.toThrow(/network|fetch/i);
+    });
+  });
+
+  describe('All providers', () => {
+    const providers = [
+      { id: 'openai', model: 'gpt-4o-mini', keyPrefix: 'sk-' },
+      { id: 'anthropic', model: 'claude-3-5-sonnet-20241022', keyPrefix: 'sk-ant-' },
+      { id: 'google', model: 'gemini-2.0-flash', keyPrefix: 'AIza' },
+      { id: 'xai', model: 'grok-2-latest', keyPrefix: 'xai-' },
+    ];
+
+    providers.forEach(({ id, model, keyPrefix }) => {
+      it(`should handle ${id} provider correctly`, async () => {
+        await setActiveProvider(id);
+        await setActiveModel(model);
+        await setProviderKey(id, `${keyPrefix}test-key-12345`);
+
+        const result = await completion('Hello', { maxTokens: 50 });
+
+        expect(result.text).toContain('Mock response');
+        expect(result.usage).toBeDefined();
+      });
+    });
+  });
+});
+```
+
+### Phase B: Expand Playwright API Tests (Backend Contract)
+
+#### B.1 Enhance Existing llm-proxy.spec.js
+
+**File:** `tests/e2e/llm-proxy.spec.js` (expand)
+
+```javascript
+import { test, expect } from '@playwright/test';
+
+const LLM_PROXY_URL = 'https://saberloop.com/llm/completion.php';
+
+test.describe('LLM Proxy API Contract', () => {
+
+  test.describe('Response Shape Validation', () => {
+    // These tests verify the backend returns expected shapes
+    // Use test API keys or mock mode on backend
+
+    test('successful response has required fields', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          provider: 'openai',
+          api_key: process.env.TEST_OPENAI_KEY || 'test-key',
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'Say "test"' }],
+          options: { max_tokens: 5 }
+        }
+      });
+
+      // Even if key is invalid, verify error shape
+      const body = await response.json();
+
+      if (response.ok()) {
+        expect(body).toHaveProperty('text');
+        expect(body).toHaveProperty('model');
+        expect(body).toHaveProperty('usage');
+        expect(body.usage).toHaveProperty('prompt_tokens');
+        expect(body.usage).toHaveProperty('completion_tokens');
+        expect(body.usage).toHaveProperty('total_tokens');
+      } else {
+        expect(body).toHaveProperty('error');
+      }
+    });
+
+    test('error response has error field', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          provider: 'openai',
+          api_key: 'definitely-invalid-key',
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'Hi' }],
+          options: {}
+        }
+      });
+
+      expect(response.ok()).toBeFalsy();
+      const body = await response.json();
+      expect(body).toHaveProperty('error');
+      expect(typeof body.error).toBe('string');
+    });
+  });
+
+  test.describe('Provider Validation', () => {
+    const validProviders = ['openai', 'anthropic', 'google', 'xai'];
+
+    validProviders.forEach(provider => {
+      test(`accepts ${provider} as valid provider`, async ({ request }) => {
+        const response = await request.post(LLM_PROXY_URL, {
+          data: {
+            provider,
+            api_key: 'test-key',
+            model: 'test-model',
+            messages: [{ role: 'user', content: 'Hi' }],
+            options: {}
+          }
+        });
+
+        // Should not be 400 "invalid provider"
+        const body = await response.json();
+        if (!response.ok()) {
+          expect(body.error).not.toMatch(/invalid provider/i);
+        }
+      });
+    });
+
+    test('rejects unknown provider', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          provider: 'unknown-provider',
+          api_key: 'test-key',
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'Hi' }],
+          options: {}
+        }
+      });
+
+      expect(response.status()).toBe(400);
+      const body = await response.json();
+      expect(body.error).toMatch(/invalid provider/i);
+    });
+  });
+
+  test.describe('Request Validation', () => {
+    test('requires provider field', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          api_key: 'test',
+          model: 'test',
+          messages: [],
+          options: {}
+        }
+      });
+
+      expect(response.status()).toBe(400);
+    });
+
+    test('requires api_key field', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          provider: 'openai',
+          model: 'test',
+          messages: [],
+          options: {}
+        }
+      });
+
+      expect(response.status()).toBe(400);
+    });
+
+    test('requires messages field', async ({ request }) => {
+      const response = await request.post(LLM_PROXY_URL, {
+        data: {
+          provider: 'openai',
+          api_key: 'test',
+          model: 'test',
+          options: {}
+        }
+      });
+
+      expect(response.status()).toBe(400);
+    });
+  });
+});
+```
+
+---
+
+## File Summary
+
+| File | Purpose |
+|------|---------|
+| `src/mocks/handlers.js` | MSW request handlers for all providers |
+| `src/mocks/server.js` | MSW server setup for Node |
+| `vitest.setup.js` | Configure MSW for all tests |
+| `src/api/provider-router.integration.test.js` | Integration tests using MSW |
+| `tests/e2e/llm-proxy.spec.js` | Backend contract tests (expand existing) |
+
+---
+
+## Testing Strategy After Implementation
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Test Pyramid                               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│                         ▲                                       │
+│                        /E\         E2E Tests (Playwright)       │
+│                       /2E \        - Full user flows            │
+│                      /Tests\       - Slow, comprehensive        │
+│                     /───────\                                   │
+│                    / API     \     API Contract Tests           │
+│                   / Contract  \    - Backend shape validation   │
+│                  /─────────────\   - Fast, no browser           │
+│                 /  Integration  \  MSW Integration Tests        │
+│                / (MSW + Vitest)  \ - Frontend logic + network   │
+│               /───────────────────\- Fast, realistic            │
+│              /     Unit Tests      \                            │
+│             /   (Vitest + mocks)    \  - Isolated logic         │
+│            /─────────────────────────\ - Fastest                │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] MSW installed and configured
+- [ ] Handlers cover all 5 providers (OpenRouter, OpenAI, Anthropic, Google, xAI)
+- [ ] Handlers cover success, auth error, rate limit, network error
+- [ ] Integration tests verify provider-router behavior
+- [ ] Playwright API tests verify backend contract
+- [ ] All tests run in CI/CD
+- [ ] Documentation updated
+
+---
+
+## Estimated Effort
+
+| Phase | Effort |
+|-------|--------|
+| A. MSW Setup + Integration Tests | 1-2 days |
+| B. Expand Playwright API Tests | 0.5-1 day |
+| **Total** | **1.5-3 days** |
+
+---
+
+## Dependencies
+
+- Epic 11 Phase 2 complete (provider-router exists)
+- Backend proxy deployed (for Playwright API tests)
+
+---
+
+## References
+
+- [MSW Documentation](https://mswjs.io/)
+- [MSW with Vitest](https://mswjs.io/docs/integrations/node)
+- [Playwright API Testing](https://playwright.dev/docs/api-testing)
+- Current tests: `tests/e2e/llm-proxy.spec.js`
+
+---
+
+*Created: January 22, 2026*
+*Last Updated: January 22, 2026*

--- a/docs/learning/epic11_llm_support/EPIC11_LLM_SUPPORT_PLAN.md
+++ b/docs/learning/epic11_llm_support/EPIC11_LLM_SUPPORT_PLAN.md
@@ -192,8 +192,8 @@ Update this section after EVERY subtask completion:
 ```
 
 **Current Progress:**
-- **Last checkpoint:** Phase 1 COMPLETE - Backend proxy deployed and tested
-- **Next action:** Begin Phase 2 - Frontend Provider Router
+- **Last checkpoint:** Phase 2 COMPLETE - Frontend provider router implemented
+- **Next action:** Begin Phase 3 - Key Management
 - **Blockers:** None
 - **Session:** January 22, 2026
 

--- a/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
+++ b/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
@@ -1,7 +1,7 @@
 # Phase 2: Frontend Provider Router
 
 **Epic:** 11 - Multi-Provider LLM Support
-**Status:** Not Started
+**Status:** In Progress
 **Effort:** 2-3 days
 **Prerequisites:** Phase 1 complete (backend proxy deployed)
 
@@ -32,12 +32,12 @@ After completing **ANY** subtask (2.1, 2.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Not started
-- **Current task:** —
-- **Completed:** —
-- **Next action:** Begin Subtask 2.1 (Create Provider Configuration)
+- **Last checkpoint:** Subtask 2.1 complete - providers-config.js created with tests
+- **Current task:** Subtask 2.2 - Create provider-router.js
+- **Completed:** 2.1 (providers-config.js + tests)
+- **Next action:** Create provider-router.js
 - **Blockers:** None
-- **Session:** —
+- **Session:** January 22, 2026
 
 ---
 
@@ -158,7 +158,7 @@ Create `docs/learning/epic10_hygiene/FLAG_MULTI_PROVIDER_LLM.md` for future clea
 
 ## Tasks
 
-### ⬚ 2.1 Create Provider Configuration
+### ✅ 2.1 Create Provider Configuration
 
 **File:** `src/api/providers-config.js`
 

--- a/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
+++ b/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
@@ -1,7 +1,7 @@
 # Phase 2: Frontend Provider Router
 
 **Epic:** 11 - Multi-Provider LLM Support
-**Status:** In Progress
+**Status:** Complete
 **Effort:** 2-3 days
 **Prerequisites:** Phase 1 complete (backend proxy deployed)
 
@@ -32,10 +32,10 @@ After completing **ANY** subtask (2.1, 2.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Subtasks 2.2 and 2.3 complete
-- **Current task:** Subtask 2.4 - Update api.real.js to use router
-- **Completed:** 2.1, 2.2, 2.3
-- **Next action:** Update api.real.js to use provider router
+- **Last checkpoint:** Phase 2 COMPLETE
+- **Current task:** —
+- **Completed:** 2.1, 2.2, 2.3, 2.4
+- **Next action:** Begin Phase 3 - Key Management
 - **Blockers:** None
 - **Session:** January 22, 2026
 
@@ -540,7 +540,7 @@ Before starting 2.4, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 2.4 Update api.real.js to Use Router
+### ✅ 2.4 Update api.real.js to Use Router
 
 **File:** `src/api/api.real.js` (modifications)
 

--- a/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
+++ b/docs/learning/epic11_llm_support/PHASE2_FRONTEND_ROUTER.md
@@ -32,10 +32,10 @@ After completing **ANY** subtask (2.1, 2.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Subtask 2.1 complete - providers-config.js created with tests
-- **Current task:** Subtask 2.2 - Create provider-router.js
-- **Completed:** 2.1 (providers-config.js + tests)
-- **Next action:** Create provider-router.js
+- **Last checkpoint:** Subtasks 2.2 and 2.3 complete
+- **Current task:** Subtask 2.4 - Update api.real.js to use router
+- **Completed:** 2.1, 2.2, 2.3
+- **Next action:** Update api.real.js to use provider router
 - **Blockers:** None
 - **Session:** January 22, 2026
 
@@ -316,7 +316,7 @@ Before starting 2.2, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 2.2 Create Provider Router
+### ✅ 2.2 Create Provider Router
 
 **File:** `src/api/provider-router.js`
 
@@ -425,7 +425,7 @@ Before starting 2.3, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 2.3 Create Provider Settings Service
+### ✅ 2.3 Create Provider Settings Service
 
 **File:** `src/services/provider-settings-service.js`
 

--- a/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
@@ -3,6 +3,7 @@
 **Epic:** 11 - Multi-Provider LLM Support
 **Phase:** 2 - Frontend Provider Router
 **Started:** January 22, 2026
+**Completed:** January 22, 2026
 
 ---
 
@@ -13,7 +14,7 @@
 | 2.1 Create Provider Configuration | ✅ Complete | January 22, 2026 |
 | 2.2 Create Provider Router | ✅ Complete | January 22, 2026 |
 | 2.3 Create Provider Settings Service | ✅ Complete | January 22, 2026 |
-| 2.4 Update api.real.js | ⬚ Pending | — |
+| 2.4 Update api.real.js | ✅ Complete | January 22, 2026 |
 
 ---
 
@@ -104,29 +105,75 @@ None significant.
 
 ## Subtask 2.4: Update api.real.js
 
-**Completed:** —
+**Completed:** January 22, 2026
 
 ### What was done
+- Replaced `callOpenRouter` import with `completion` from provider-router
+- Updated all three LLM call sites:
+  - `generateQuestions` - Quiz generation
+  - `generateExplanation` - Answer explanations
+  - `generateWrongAnswerExplanation` - Wrong answer explanations
+- Updated all tests to mock `completion` instead of `callOpenRouter`
+- Fixed mock call parameter access (prompt now at index [0] instead of [1])
+- All 1262 tests passing
 
 ### Difficulties encountered
+- Test file had extensive mocking of `callOpenRouter` that needed updating
+- Mock parameter access changed from `mock.calls[n][1]` to `mock.calls[n][0]`
 
 ### Solutions applied
+- Systematic search and replace of all `callOpenRouter` references
+- Updated parameter index references for the new function signature
 
 ### Key learnings
+- The `apiKey` parameter in generateQuestions is now ignored when feature is enabled
+- Provider router handles key retrieval internally from settings
+- Minimal changes to business logic - just swapped the API call function
 
 ---
 
 ## Phase Summary
 
-**Phase completed:** —
+**Phase completed:** January 22, 2026
 
 ### Overall learnings
+- Feature flag pattern works well for gradual rollout
+- Provider router is a thin abstraction layer that routes based on provider CORS support
+- Existing code patterns (IndexedDB settings, OpenRouter client) were easily integrated
+- Dependency between subtasks 2.2 and 2.3 was discovered during implementation
 
 ### What went well
+- All subtasks completed in a single session
+- Test suite remained stable (1262 tests passing)
+- No breaking changes to existing functionality
+- Clean separation between routing logic and business logic
 
 ### What could be improved
+- Phase document could have noted the 2.2/2.3 dependency upfront
+- Could add more E2E tests for the routing paths
 
 ### Recommendations for next phase
+- Phase 3 (Key Management) can build on the provider-settings-service
+- Settings UI will need to interact with the settings service
+- Consider adding key validation on save (async background validation)
+
+---
+
+## Files Created/Modified
+
+### New Files
+- `src/api/providers-config.js` - Provider configuration (32 tests)
+- `src/api/providers-config.test.js` - Provider config tests
+- `src/api/provider-router.js` - Provider routing (16 tests)
+- `src/api/provider-router.test.js` - Provider router tests
+- `src/services/provider-settings-service.js` - Settings service (22 tests)
+- `src/services/provider-settings-service.test.js` - Settings service tests
+- `src/core/features.js` - Added MULTI_PROVIDER_LLM flag
+- `docs/learning/epic10_hygiene/FLAG_MULTI_PROVIDER_LLM.md` - Flag documentation
+
+### Modified Files
+- `src/api/api.real.js` - Updated to use completion from provider-router
+- `src/api/api.real.test.js` - Updated mocks for completion
 
 ---
 

--- a/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
@@ -150,7 +150,7 @@ None significant.
 
 ### What could be improved
 - Phase document could have noted the 2.2/2.3 dependency upfront
-- Could add more E2E tests for the routing paths
+- E2E tests for new provider routing paths should be added in Phase 4 (Settings UI) when the UI is available to exercise them
 
 ### Recommendations for next phase
 - Phase 3 (Key Management) can build on the provider-settings-service

--- a/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
@@ -2,7 +2,7 @@
 
 **Epic:** 11 - Multi-Provider LLM Support
 **Phase:** 2 - Frontend Provider Router
-**Started:** —
+**Started:** January 22, 2026
 
 ---
 
@@ -10,7 +10,7 @@
 
 | Subtask | Status | Session Date |
 |---------|--------|--------------|
-| 2.1 Create Provider Configuration | ⬚ Pending | — |
+| 2.1 Create Provider Configuration | ✅ Complete | January 22, 2026 |
 | 2.2 Create Provider Router | ⬚ Pending | — |
 | 2.3 Create Provider Settings Service | ⬚ Pending | — |
 | 2.4 Update api.real.js | ⬚ Pending | — |
@@ -19,19 +19,31 @@
 
 ## Subtask 2.1: Create Provider Configuration
 
-**Completed:** —
+**Completed:** January 22, 2026
 
 ### What was done
-<!-- Fill after completing subtask -->
+- Created `src/api/providers-config.js` with configuration for all 5 LLM providers
+- Defined provider properties: id, name, description, cors support, key patterns, models, pricing
+- Implemented helper functions:
+  - `getProvider(providerId)` - Get provider by ID
+  - `getAllProviders()` - Get all providers as array
+  - `supportsCors(providerId)` - Check if provider supports direct browser calls
+  - `validateKeyFormat(providerId, key)` - Validate API key format
+  - `estimateCost(providerId, modelId, inputTokens, outputTokens)` - Calculate request cost
+  - `getDefaultModel(providerId)` - Get default model for provider (added beyond spec)
+- Created comprehensive unit tests (32 tests, all passing)
 
 ### Difficulties encountered
-<!-- Any challenges, confusion, unexpected issues -->
+None - implementation was straightforward following the spec.
 
 ### Solutions applied
-<!-- How issues were resolved -->
+N/A
 
 ### Key learnings
-<!-- Insights, patterns discovered, gotchas for future -->
+- Key validation uses regex patterns specific to each provider
+- Only OpenRouter supports CORS (direct browser calls)
+- Model pricing stored as per-million-token costs for consistency
+- Added `getDefaultModel()` helper beyond original spec - useful for initialization
 
 ---
 
@@ -91,4 +103,4 @@
 
 ---
 
-*Last Updated: —*
+*Last Updated: January 22, 2026*

--- a/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md
@@ -11,8 +11,8 @@
 | Subtask | Status | Session Date |
 |---------|--------|--------------|
 | 2.1 Create Provider Configuration | ✅ Complete | January 22, 2026 |
-| 2.2 Create Provider Router | ⬚ Pending | — |
-| 2.3 Create Provider Settings Service | ⬚ Pending | — |
+| 2.2 Create Provider Router | ✅ Complete | January 22, 2026 |
+| 2.3 Create Provider Settings Service | ✅ Complete | January 22, 2026 |
 | 2.4 Update api.real.js | ⬚ Pending | — |
 
 ---
@@ -49,29 +49,56 @@ N/A
 
 ## Subtask 2.2: Create Provider Router
 
-**Completed:** —
+**Completed:** January 22, 2026
 
 ### What was done
+- Created `src/api/provider-router.js` with main `completion()` function
+- Implemented feature flag check for backward compatibility
+- OpenRouter: direct browser call via existing `callOpenRouter`
+- Other providers: route through backend proxy at `/llm/completion.php`
+- Added `getActiveProviderInfo()` helper for UI display
+- 16 unit tests passing
 
 ### Difficulties encountered
+- **Dependency on provider-settings-service**: The spec listed 2.2 before 2.3, but provider-router imports from provider-settings-service. Had to implement both in the same session.
 
 ### Solutions applied
+- Implemented subtasks 2.2 and 2.3 together to resolve the dependency
+- Followed the pattern of the existing `callOpenRouter` function (takes prompt string, not messages array)
 
 ### Key learnings
+- The router maintains backward compatibility via feature flag - when DISABLED, uses legacy OpenRouter behavior
+- Error handling includes status code fallback when JSON parsing fails
+- Provider router is a thin routing layer - business logic stays in api.real.js
 
 ---
 
 ## Subtask 2.3: Create Provider Settings Service
 
-**Completed:** —
+**Completed:** January 22, 2026
 
 ### What was done
+- Created `src/services/provider-settings-service.js`
+- Implemented functions:
+  - `getActiveProvider()` / `setActiveProvider()` - Manage active provider
+  - `getActiveModel()` / `setActiveModel()` - Manage active model
+  - `getProviderKey()` / `setProviderKey()` / `removeProviderKey()` - API key management
+  - `hasProviderKey()` - Check if provider is configured
+  - `getConfiguredProviders()` - List all configured providers
+- Special handling for OpenRouter to use existing `getOpenRouterKey()` from db.js
+- 22 unit tests passing
 
 ### Difficulties encountered
+None significant.
 
 ### Solutions applied
+- Reused existing OpenRouter key storage mechanism from db.js for backward compatibility
+- Used consistent `llm_*` key prefix for new settings
 
 ### Key learnings
+- Integration with existing IndexedDB pattern was smooth
+- OpenRouter special case: use existing `storeOpenRouterKey`/`getOpenRouterKey` from db.js
+- Settings keys use `llm_` prefix for easy identification
 
 ---
 

--- a/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
+++ b/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
@@ -9,7 +9,9 @@
 
 ## Goal
 
-Implement API key storage, validation, and management. Include hybrid validation approach (format check on save, async validation in background).
+Extend the existing `provider-settings-service.js` (from Phase 2) with key status tracking and async validation. Include hybrid validation approach (format check on save, async validation in background).
+
+**Important:** Phase 2 already created key storage functions in `provider-settings-service.js`. This phase EXTENDS that service rather than creating a new one to avoid duplication.
 
 ---
 
@@ -55,65 +57,71 @@ feature/epic11-phase3-key-management
 main (with Phase 2 merged)
   │
   └── feature/epic11-phase3-key-management
-        ├── commit: feat(llm): add api-keys-service with storage and format validation
+        ├── commit: feat(llm): add key status tracking to provider-settings-service
         ├── commit: feat(llm): add async key validation
         ├── commit: feat(llm): add OpenRouter key migration
-        ├── commit: test(llm): add unit tests for api-keys-service
-        ├── commit: test(llm): add E2E tests for key management
-        ├── commit: test(llm): add Maestro tests for key management
+        ├── commit: test(llm): add unit tests for key status and validation
         └── PR → merge to main
 ```
+
+**Note:** E2E and Maestro tests for key management UI will be added in Phase 4 when the Settings UI is implemented. This phase runs all existing tests for regression testing.
 
 ### Commit Message Format
 
 ```
-feat(llm): add api-keys-service with storage and format validation
+feat(llm): add key status tracking to provider-settings-service
 
-- Implement saveProviderKey with format check
 - Add KEY_STATUS enum (NOT_SET, VALIDATING, VALID, INVALID)
-- Store keys in IndexedDB with llm_key_ prefix
-- Add masked key display utility
+- Add key status tracking with llm_key_status_ prefix
+- Add getMaskedKey() utility for display
+- Add getAllProviderStatuses() for UI consumption
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
 
 ---
 
 ## Tasks
 
-### ⬚ 3.1 Create API Keys Service
+### ⬚ 3.1 Add Key Status and Validation to provider-settings-service.js
 
-**File:** `src/services/api-keys-service.js`
+**File:** `src/services/provider-settings-service.js` (EXTEND existing file from Phase 2)
+
+Phase 2 already created this service with:
+- `getProviderKey(providerId)` - Get API key
+- `setProviderKey(providerId, key)` - Save API key
+- `removeProviderKey(providerId)` - Remove API key
+- `hasProviderKey(providerId)` - Check if key exists
+- `getConfiguredProviders()` - List providers with keys
+
+**Add these new exports to the existing file:**
 
 ```javascript
-/**
- * API Keys Service
- * Handles key storage, validation, and status tracking
- */
-
-import { db } from '../core/db.js';
-import { getProvider, validateKeyFormat } from '../api/providers-config.js';
+// Add imports at top of file
+import { getProvider, validateKeyFormat, getAllProviders } from '../api/providers-config.js';
 import { logger } from '../utils/logger.js';
 
-const KEY_STATUS = {
+// Add KEY_STATUS enum
+export const KEY_STATUS = {
   NOT_SET: 'not_set',
   VALIDATING: 'validating',
   VALID: 'valid',
   INVALID: 'invalid'
 };
 
+// Add to SETTINGS_KEYS
 const SETTINGS_KEYS = {
-  KEY_PREFIX: 'llm_key_',
-  STATUS_PREFIX: 'llm_key_status_'
+  ACTIVE_PROVIDER: 'llm_active_provider',
+  ACTIVE_MODEL: 'llm_active_model',
+  PROVIDER_KEY_PREFIX: 'llm_key_',
+  KEY_STATUS_PREFIX: 'llm_key_status_'  // NEW
 };
 
 /**
- * Save API key for a provider
- * Validates format, saves key, triggers async validation
+ * Save API key with format validation and async validation trigger
+ * Enhanced version of setProviderKey with validation
  */
-export async function saveProviderKey(providerId, apiKey) {
+export async function saveProviderKeyWithValidation(providerId, apiKey) {
   const provider = getProvider(providerId);
   if (!provider) {
     throw new Error(`Unknown provider: ${providerId}`);
@@ -124,53 +132,40 @@ export async function saveProviderKey(providerId, apiKey) {
     throw new Error(`Invalid key format. ${provider.name} keys should start with '${provider.keyPrefix}'`);
   }
 
-  // Save key
-  await db.settings.put({
-    key: SETTINGS_KEYS.KEY_PREFIX + providerId,
-    value: apiKey
-  });
+  // Save key using existing function
+  await setProviderKey(providerId, apiKey);
 
   // Set status to validating
   await setKeyStatus(providerId, KEY_STATUS.VALIDATING);
 
-  // Trigger async validation
+  // Trigger async validation (fire and forget)
   validateKeyAsync(providerId, apiKey);
 
   return { status: KEY_STATUS.VALIDATING };
 }
 
 /**
- * Get API key for a provider
- */
-export async function getProviderKey(providerId) {
-  const setting = await db.settings.get(SETTINGS_KEYS.KEY_PREFIX + providerId);
-  return setting?.value || null;
-}
-
-/**
- * Remove API key for a provider
- */
-export async function removeProviderKey(providerId) {
-  await db.settings.delete(SETTINGS_KEYS.KEY_PREFIX + providerId);
-  await db.settings.delete(SETTINGS_KEYS.STATUS_PREFIX + providerId);
-}
-
-/**
- * Get key status
+ * Get key status for a provider
  */
 export async function getKeyStatus(providerId) {
-  const setting = await db.settings.get(SETTINGS_KEYS.STATUS_PREFIX + providerId);
-  return setting?.value || KEY_STATUS.NOT_SET;
+  const status = await getSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId);
+  return status || KEY_STATUS.NOT_SET;
 }
 
 /**
- * Set key status
+ * Set key status (internal helper)
  */
 async function setKeyStatus(providerId, status) {
-  await db.settings.put({
-    key: SETTINGS_KEYS.STATUS_PREFIX + providerId,
-    value: status
-  });
+  await saveSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId, status);
+}
+
+/**
+ * Clear key status when removing a key
+ * Update existing removeProviderKey to also clear status
+ */
+export async function removeProviderKeyWithStatus(providerId) {
+  await removeProviderKey(providerId);
+  await saveSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId, null);
 }
 
 /**
@@ -184,13 +179,70 @@ export function getMaskedKey(apiKey) {
 }
 
 /**
+ * Get all provider statuses for UI display
+ */
+export async function getAllProviderStatuses() {
+  const providers = getAllProviders();
+  const statuses = {};
+
+  for (const provider of providers) {
+    const key = await getProviderKey(provider.id);
+    const status = await getKeyStatus(provider.id);
+
+    statuses[provider.id] = {
+      hasKey: !!key,
+      maskedKey: key ? getMaskedKey(key) : null,
+      status: key ? status : KEY_STATUS.NOT_SET
+    };
+  }
+
+  return statuses;
+}
+
+/**
+ * Re-validate a key (manual trigger from UI)
+ */
+export async function revalidateKey(providerId) {
+  const apiKey = await getProviderKey(providerId);
+  if (!apiKey) {
+    throw new Error('No key configured');
+  }
+
+  await setKeyStatus(providerId, KEY_STATUS.VALIDATING);
+  validateKeyAsync(providerId, apiKey);
+}
+```
+
+**Verification:**
+- Run new unit tests for key status and validation
+- Run ALL existing unit tests (1262+) for regression
+- Verify key status tracking works
+
+---
+
+#### 🛑 CHECKPOINT: After completing 3.1
+
+Before starting 3.2, complete the [Subtask Completion Checklist](#subtask-completion-checklist).
+
+---
+
+### ⬚ 3.2 Add Async Key Validation Functions
+
+**File:** `src/services/provider-settings-service.js` (continue extending)
+
+Add async validation functions that test keys against providers:
+
+```javascript
+import { supportsCors } from '../api/providers-config.js';
+
+/**
  * Async validation - makes test call to provider
+ * Called after key is saved, updates status when complete
  */
 async function validateKeyAsync(providerId, apiKey) {
   try {
     logger.debug(`Validating ${providerId} key...`);
 
-    // Small test request
     const isValid = await testProviderKey(providerId, apiKey);
 
     if (isValid) {
@@ -210,19 +262,17 @@ async function validateKeyAsync(providerId, apiKey) {
  * Test provider key with minimal request
  */
 async function testProviderKey(providerId, apiKey) {
-  const provider = getProvider(providerId);
-
-  if (provider.cors) {
-    // OpenRouter - direct test
+  if (supportsCors(providerId)) {
+    // OpenRouter - direct test via auth endpoint
     return await testOpenRouterKey(apiKey);
   } else {
-    // Other providers - test via proxy
+    // Other providers - test via proxy with minimal request
     return await testViaProxy(providerId, apiKey);
   }
 }
 
 /**
- * Test OpenRouter key directly
+ * Test OpenRouter key directly (CORS supported)
  */
 async function testOpenRouterKey(apiKey) {
   try {
@@ -232,7 +282,6 @@ async function testOpenRouterKey(apiKey) {
         'Authorization': `Bearer ${apiKey}`
       }
     });
-
     return response.ok;
   } catch (error) {
     return false;
@@ -240,152 +289,33 @@ async function testOpenRouterKey(apiKey) {
 }
 
 /**
- * Test other provider keys via proxy
+ * Test other provider keys via backend proxy
  */
 async function testViaProxy(providerId, apiKey) {
   try {
+    const provider = getProvider(providerId);
     const response = await fetch('https://saberloop.com/llm/completion.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         provider: providerId,
         api_key: apiKey,
-        model: getProvider(providerId).defaultModel,
+        model: provider.defaultModel,
         messages: [{ role: 'user', content: 'Hi' }],
         options: { max_tokens: 5 }
       })
     });
-
     return response.ok;
   } catch (error) {
     return false;
   }
 }
-
-/**
- * Re-validate a key (manual trigger)
- */
-export async function revalidateKey(providerId) {
-  const apiKey = await getProviderKey(providerId);
-  if (!apiKey) {
-    throw new Error('No key configured');
-  }
-
-  await setKeyStatus(providerId, KEY_STATUS.VALIDATING);
-  validateKeyAsync(providerId, apiKey);
-}
-
-/**
- * Get all provider statuses
- */
-export async function getAllProviderStatuses() {
-  const providers = ['openrouter', 'openai', 'anthropic', 'google', 'xai'];
-  const statuses = {};
-
-  for (const providerId of providers) {
-    const key = await getProviderKey(providerId);
-    const status = await getKeyStatus(providerId);
-
-    statuses[providerId] = {
-      hasKey: !!key,
-      maskedKey: key ? getMaskedKey(key) : null,
-      status: key ? status : KEY_STATUS.NOT_SET
-    };
-  }
-
-  return statuses;
-}
-
-export { KEY_STATUS };
 ```
 
-**Verification:** Run unit tests for api-keys-service.js, verify key storage, masking, and validation logic.
-
----
-
-#### 🛑 CHECKPOINT: After completing 3.1
-
-Before starting 3.2, complete the [Subtask Completion Checklist](#subtask-completion-checklist).
-
----
-
-### ⬚ 3.2 Migrate OpenRouter Key
-
-Handle migration of existing OpenRouter key to new storage format.
-
-**File:** `src/services/api-keys-migration.js`
-
-```javascript
-/**
- * API Keys Migration
- * Migrates existing OpenRouter key to new format
- */
-
-import { db } from '../core/db.js';
-import { saveProviderKey, getProviderKey } from './api-keys-service.js';
-import { logger } from '../utils/logger.js';
-
-const MIGRATION_FLAG = 'llm_keys_migrated_v1';
-
-/**
- * Run migration if needed
- */
-export async function migrateApiKeys() {
-  const migrated = await db.settings.get(MIGRATION_FLAG);
-  if (migrated) {
-    return; // Already migrated
-  }
-
-  logger.info('Migrating API keys...');
-
-  try {
-    // Check for existing OpenRouter key in old location
-    const oldKey = await getOldOpenRouterKey();
-
-    if (oldKey) {
-      // Check if already in new location
-      const newKey = await getProviderKey('openrouter');
-
-      if (!newKey) {
-        await saveProviderKey('openrouter', oldKey);
-        logger.info('OpenRouter key migrated to new storage');
-      }
-    }
-
-    // Mark migration complete
-    await db.settings.put({
-      key: MIGRATION_FLAG,
-      value: true
-    });
-
-    logger.info('API key migration complete');
-  } catch (error) {
-    logger.error('API key migration failed:', error);
-    // Don't fail - user can re-add key manually
-  }
-}
-
-/**
- * Get OpenRouter key from old storage location
- */
-async function getOldOpenRouterKey() {
-  // Check IndexedDB settings
-  const setting = await db.settings.get('openrouter_api_key');
-  if (setting?.value) {
-    return setting.value;
-  }
-
-  // Check localStorage (legacy)
-  const localStorageKey = localStorage.getItem('openrouter_api_key');
-  if (localStorageKey) {
-    return localStorageKey;
-  }
-
-  return null;
-}
-```
-
-**Verification:** Run migration manually with existing OpenRouter key, verify it migrates correctly.
+**Verification:**
+- Run new unit tests for async validation
+- Run ALL existing unit tests for regression
+- Test validation with a real key (manual verification)
 
 ---
 
@@ -395,7 +325,91 @@ Before starting 3.3, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 3.3 Update Main Entry Point
+### ⬚ 3.3 Migrate OpenRouter Key
+
+Handle migration of existing OpenRouter key to trigger validation status.
+
+**Important Context:** Phase 2's `provider-settings-service.js` already uses the existing `getOpenRouterKey()` and `storeOpenRouterKey()` from `db.js` for backward compatibility. The "migration" here is mainly to:
+1. Set initial key status for existing OpenRouter keys
+2. Handle any legacy localStorage keys
+
+**File:** `src/services/api-keys-migration.js`
+
+```javascript
+/**
+ * API Keys Migration
+ * Sets up initial key status for existing OpenRouter keys
+ */
+
+import { getSetting, saveSetting } from '../core/db.js';
+import { getOpenRouterKey } from '../core/db.js';
+import { getKeyStatus, KEY_STATUS } from './provider-settings-service.js';
+import { logger } from '../utils/logger.js';
+
+const MIGRATION_FLAG = 'llm_keys_migrated_v1';
+
+/**
+ * Run migration if needed
+ */
+export async function migrateApiKeys() {
+  const migrated = await getSetting(MIGRATION_FLAG);
+  if (migrated) {
+    return; // Already migrated
+  }
+
+  logger.info('Migrating API keys...');
+
+  try {
+    // Check for existing OpenRouter key (uses existing db.js mechanism)
+    const existingKey = await getOpenRouterKey();
+
+    if (existingKey) {
+      // Check if status already set
+      const status = await getKeyStatus('openrouter');
+
+      if (status === KEY_STATUS.NOT_SET) {
+        // Set initial status - mark as valid since it was working
+        // (User can revalidate if needed)
+        await saveSetting('llm_key_status_openrouter', KEY_STATUS.VALID);
+        logger.info('OpenRouter key status initialized');
+      }
+    }
+
+    // Check localStorage for legacy keys (from very old versions)
+    const legacyKey = localStorage.getItem('openrouter_api_key');
+    if (legacyKey && !existingKey) {
+      // Import legacy key to IndexedDB
+      const { storeOpenRouterKey } = await import('../core/db.js');
+      await storeOpenRouterKey(legacyKey);
+      await saveSetting('llm_key_status_openrouter', KEY_STATUS.VALID);
+      localStorage.removeItem('openrouter_api_key');
+      logger.info('Legacy OpenRouter key migrated from localStorage');
+    }
+
+    // Mark migration complete
+    await saveSetting(MIGRATION_FLAG, true);
+
+    logger.info('API key migration complete');
+  } catch (error) {
+    logger.error('API key migration failed:', error);
+    // Don't fail app startup - user can re-add key manually
+  }
+}
+```
+
+**Verification:**
+- Run migration with existing OpenRouter key, verify status is set
+- Run ALL existing tests for regression
+
+---
+
+#### 🛑 CHECKPOINT: After completing 3.3
+
+Before starting 3.4, complete the [Subtask Completion Checklist](#subtask-completion-checklist).
+
+---
+
+### ⬚ 3.4 Update Main Entry Point
 
 Add migration call to app initialization.
 
@@ -415,11 +429,14 @@ async function initializeApp() {
 }
 ```
 
-**Verification:** Run app initialization, verify migration runs without errors and only once.
+**Verification:**
+- Run app initialization, verify migration runs without errors and only once
+- Run ALL existing unit tests (1262+) for regression
+- Run ALL existing E2E tests (178) for regression
 
 ---
 
-#### 🛑 CHECKPOINT: After completing 3.3
+#### 🛑 CHECKPOINT: After completing 3.4
 
 Phase 3 complete! Complete the [Subtask Completion Checklist](#subtask-completion-checklist), then proceed to Phase 4.
 
@@ -427,55 +444,46 @@ Phase 3 complete! Complete the [Subtask Completion Checklist](#subtask-completio
 
 ## Testing
 
-### Unit Tests
+### Unit Tests (New)
 
-**File:** `tests/unit/api-keys-service.test.js`
+**File:** `src/services/provider-settings-service.test.js` (extend existing test file)
+
+Add tests for the new key status and validation functionality:
 
 ```javascript
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// Add to existing provider-settings-service.test.js
+
 import {
-  saveProviderKey,
-  getProviderKey,
-  removeProviderKey,
+  // ... existing imports ...
   getKeyStatus,
   getMaskedKey,
-  KEY_STATUS
-} from '../../src/services/api-keys-service.js';
-import { db } from '../../src/core/db.js';
+  getAllProviderStatuses,
+  saveProviderKeyWithValidation,
+  removeProviderKeyWithStatus,
+  revalidateKey,
+  KEY_STATUS,
+} from './provider-settings-service.js';
 
-// Mock db
-vi.mock('../../src/core/db.js', () => ({
-  db: {
-    settings: {
-      put: vi.fn(),
-      get: vi.fn(),
-      delete: vi.fn()
-    }
-  }
-}));
-
-// Mock fetch for validation
+// Mock fetch for validation tests
 global.fetch = vi.fn();
 
-describe('API Keys Service', () => {
+describe('Key Status and Validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch.mockReset();
   });
 
-  describe('saveProviderKey', () => {
-    it('should reject invalid key format', async () => {
-      await expect(saveProviderKey('openai', 'invalid-key'))
-        .rejects.toThrow('Invalid key format');
+  describe('getKeyStatus', () => {
+    it('should return NOT_SET when no status stored', async () => {
+      getSetting.mockResolvedValue(null);
+      const status = await getKeyStatus('openai');
+      expect(status).toBe(KEY_STATUS.NOT_SET);
     });
 
-    it('should save valid key and trigger validation', async () => {
-      db.settings.put.mockResolvedValue();
-      global.fetch.mockResolvedValue({ ok: true });
-
-      const result = await saveProviderKey('openai', 'sk-validkey123');
-
-      expect(db.settings.put).toHaveBeenCalled();
-      expect(result.status).toBe(KEY_STATUS.VALIDATING);
+    it('should return stored status', async () => {
+      getSetting.mockResolvedValue(KEY_STATUS.VALID);
+      const status = await getKeyStatus('openai');
+      expect(status).toBe(KEY_STATUS.VALID);
     });
   });
 
@@ -494,131 +502,80 @@ describe('API Keys Service', () => {
     });
   });
 
-  describe('removeProviderKey', () => {
-    it('should remove key and status', async () => {
-      db.settings.delete.mockResolvedValue();
+  describe('saveProviderKeyWithValidation', () => {
+    it('should reject invalid key format', async () => {
+      await expect(saveProviderKeyWithValidation('openai', 'invalid-key'))
+        .rejects.toThrow('Invalid key format');
+    });
 
-      await removeProviderKey('openai');
+    it('should save valid key and return validating status', async () => {
+      getSetting.mockResolvedValue(null);
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: true });
 
-      expect(db.settings.delete).toHaveBeenCalledTimes(2);
+      const result = await saveProviderKeyWithValidation('openai', 'sk-validkey123456789');
+
+      expect(saveSetting).toHaveBeenCalled();
+      expect(result.status).toBe(KEY_STATUS.VALIDATING);
+    });
+  });
+
+  describe('removeProviderKeyWithStatus', () => {
+    it('should remove key and clear status', async () => {
+      saveSetting.mockResolvedValue();
+
+      await removeProviderKeyWithStatus('openai');
+
+      // Should call saveSetting to clear status
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', null);
+    });
+  });
+
+  describe('getAllProviderStatuses', () => {
+    it('should return status for all providers', async () => {
+      getSetting.mockResolvedValue(null);
+      getOpenRouterKey.mockResolvedValue(null);
+
+      const statuses = await getAllProviderStatuses();
+
+      expect(statuses).toHaveProperty('openrouter');
+      expect(statuses).toHaveProperty('openai');
+      expect(statuses).toHaveProperty('anthropic');
+      expect(statuses).toHaveProperty('google');
+      expect(statuses).toHaveProperty('xai');
     });
   });
 });
 ```
 
-### E2E Tests
+### Regression Testing (Existing Tests)
 
-**File:** `tests/e2e/api-keys.spec.js`
+After completing Phase 3, run ALL existing tests to ensure no regressions:
 
-```javascript
-import { test, expect } from '@playwright/test';
+```bash
+# Run all unit tests (should be 1262+ tests)
+npm test -- --run
 
-test.describe('API Key Management', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/app/');
-  });
-
-  test('should store and retrieve API key', async ({ page }) => {
-    // Navigate to settings
-    await page.click('[data-testid="settings-button"]');
-
-    // Add OpenAI key
-    await page.click('[data-testid="add-key-openai"]');
-    await page.fill('[data-testid="api-key-input"]', 'sk-test123456789');
-    await page.click('[data-testid="save-key-button"]');
-
-    // Verify key is masked
-    await expect(page.locator('[data-testid="openai-masked-key"]'))
-      .toContainText('sk-te...6789');
-
-    // Verify status shows validating or valid
-    await expect(page.locator('[data-testid="openai-status"]'))
-      .toHaveText(/Validating|Valid|Invalid/);
-  });
-
-  test('should reject invalid key format', async ({ page }) => {
-    await page.click('[data-testid="settings-button"]');
-    await page.click('[data-testid="add-key-openai"]');
-    await page.fill('[data-testid="api-key-input"]', 'invalid-format');
-    await page.click('[data-testid="save-key-button"]');
-
-    // Should show format error
-    await expect(page.locator('[data-testid="key-error"]'))
-      .toContainText('Invalid key format');
-  });
-
-  test('should remove API key', async ({ page }) => {
-    // First add a key
-    await page.click('[data-testid="settings-button"]');
-    await page.click('[data-testid="add-key-openai"]');
-    await page.fill('[data-testid="api-key-input"]', 'sk-test123456789');
-    await page.click('[data-testid="save-key-button"]');
-
-    // Now remove it
-    await page.click('[data-testid="remove-key-openai"]');
-    await page.click('[data-testid="confirm-remove"]');
-
-    // Verify key is removed
-    await expect(page.locator('[data-testid="openai-status"]'))
-      .toContainText('Not configured');
-  });
-});
+# Run all E2E tests (should be 178 tests)
+npm run test:e2e
 ```
 
-### Maestro Tests
-
-**File:** `tests/maestro/api_key_management.yaml`
-
-```yaml
-appId: com.saberloop.app
----
-- launchApp
-
-# Navigate to settings
-- tapOn:
-    id: "settings-button"
-
-# Scroll to LLM Providers section
-- scrollUntilVisible:
-    element: "LLM Providers"
-    direction: DOWN
-
-# Add OpenAI key
-- tapOn:
-    id: "add-key-openai"
-
-# Enter API key
-- inputText:
-    id: "api-key-input"
-    text: "sk-test123456789"
-
-# Save
-- tapOn:
-    id: "save-key-button"
-
-# Verify key appears masked
-- assertVisible:
-    text: "sk-te...6789"
-
-# Verify status indicator
-- assertVisible:
-    text: "Validating|Valid|Invalid"
-    regex: true
-```
+**Note:** E2E and Maestro tests for the key management **UI** will be added in Phase 4 when the Settings UI is implemented. The tests above verify the service layer only.
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] Keys stored securely in IndexedDB
+- [ ] Key status tracking works (NOT_SET, VALIDATING, VALID, INVALID)
 - [ ] Format validation rejects invalid keys
-- [ ] Async validation updates status
-- [ ] Masked key display works correctly
-- [ ] Key removal works
-- [ ] Migration runs for existing OpenRouter keys
-- [ ] All unit tests pass
-- [ ] E2E tests pass
-- [ ] Maestro tests pass
+- [ ] Async validation updates status correctly
+- [ ] Masked key display works correctly (`getMaskedKey()`)
+- [ ] Key removal clears status (`removeProviderKeyWithStatus()`)
+- [ ] `getAllProviderStatuses()` returns correct data for UI
+- [ ] Migration sets initial status for existing OpenRouter keys
+- [ ] All NEW unit tests pass
+- [ ] All EXISTING unit tests pass (1262+ - regression)
+- [ ] All EXISTING E2E tests pass (178 - regression)
 
 ---
 
@@ -636,11 +593,11 @@ appId: com.saberloop.app
 ### 1. Run Unit Tests
 
 ```bash
-# Run all unit tests
-npm test
+# Run all unit tests (including new ones)
+npm test -- --run
 
-# Run specific key management tests
-npm test -- api-keys-service
+# Run specific provider settings tests
+npm test -- provider-settings-service
 ```
 
 ### 2. Test with Dev Server
@@ -649,24 +606,35 @@ npm test -- api-keys-service
 # Start development server
 npm run dev
 
-# Enable feature flag in browser console
-localStorage.setItem('__test_feature_MULTI_PROVIDER_LLM', 'ENABLED');
-location.reload();
+# Test key status operations via browser console:
+import {
+  saveProviderKeyWithValidation,
+  getKeyStatus,
+  getMaskedKey,
+  getAllProviderStatuses,
+  KEY_STATUS
+} from './src/services/provider-settings-service.js';
 
-# Test key operations via browser console:
-# - Import and call saveProviderKey()
-# - Verify key is stored in IndexedDB
-# - Check status changes (validating → valid/invalid)
+# Test saving a key with validation
+await saveProviderKeyWithValidation('openai', 'sk-test123456789012345');
+
+# Check status (should be VALIDATING initially)
+await getKeyStatus('openai');
+
+# Test masking
+getMaskedKey('sk-test123456789012345'); // 'sk-te...2345'
+
+# Get all statuses for UI
+await getAllProviderStatuses();
 ```
 
 ### 3. Test Migration
 
 ```bash
-# If you have an existing OpenRouter OAuth token, test migration:
-# 1. Clear IndexedDB
-# 2. Add OpenRouter token to localStorage (as done currently)
-# 3. Run migration
-# 4. Verify key appears in IndexedDB with status
+# If you have an existing OpenRouter OAuth token:
+# 1. Refresh the app
+# 2. Migration should run automatically
+# 3. Check that llm_key_status_openrouter is set to 'valid'
 ```
 
 ---
@@ -676,52 +644,31 @@ location.reload();
 ### Step 1: Local Testing (Required)
 
 Complete all local testing steps above. Verify:
-- [ ] Unit tests pass
-- [ ] Key storage works in IndexedDB
-- [ ] Format validation rejects invalid keys
-- [ ] Async validation updates status
-- [ ] Migration works for existing OpenRouter keys
+- [ ] All new unit tests pass
+- [ ] All existing unit tests pass (1262+ - regression)
+- [ ] All existing E2E tests pass (178 - regression)
+- [ ] Key status tracking works correctly
+- [ ] Migration runs successfully for existing OpenRouter keys
 
-### Step 2: Deploy to Staging
-
-```bash
-npm run build:staging && npm run deploy:staging
-```
-
-### Step 3: Test Staging with Feature Flag ENABLED
+### Step 2: Merge to Main
 
 ```bash
-# Visit https://saberloop.com/app-staging/
-# Enable feature flag in console:
-localStorage.setItem('__test_feature_MULTI_PROVIDER_LLM', 'ENABLED');
-location.reload();
+# Create PR from feature/epic11-phase3-key-management
+gh pr create --title "feat(llm): Phase 3 - Key status tracking and validation" --body "..."
+
+# After review, merge to main
 ```
 
-**Staging Verification Checklist:**
-- [ ] Key storage works correctly
-- [ ] Validation updates status
-- [ ] Migration works if OpenRouter token exists
-- [ ] No errors in console
-
-### Step 4: Run E2E and Maestro Tests on Staging
-
-```bash
-# E2E tests
-PLAYWRIGHT_BASE_URL=https://saberloop.com/app-staging/ npm run test:e2e
-
-# Maestro tests (on device/emulator)
-maestro test tests/maestro/key_management.yaml
-```
-
-### Step 5: Deploy to Production (keep SETTINGS_ONLY)
+### Step 3: Deploy to Production
 
 ```bash
 npm run build && npm run deploy
 ```
 
 **Production Verification:**
-- [ ] Feature flag remains `SETTINGS_ONLY`
-- [ ] No user-visible changes yet
+- [ ] Feature flag remains `DISABLED` or `SETTINGS_ONLY`
+- [ ] No user-visible changes (no UI yet)
+- [ ] Migration runs silently for existing users
 - [ ] Background services ready for Phase 4 UI
 
 ---

--- a/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
@@ -1,8 +1,9 @@
-# Phase 3: API Key Management - Learning Notes
+# Phase 3: Key Management - Learning Notes
 
 **Epic:** 11 - Multi-Provider LLM Support
 **Phase:** 3 - API Key Management
 **Started:** —
+**Completed:** —
 
 ---
 
@@ -10,69 +11,16 @@
 
 | Subtask | Status | Session Date |
 |---------|--------|--------------|
-| 3.1 Create API Keys Service | ⬚ Pending | — |
-| 3.2 Migrate OpenRouter Key | ⬚ Pending | — |
-| 3.3 Update Main Entry Point | ⬚ Pending | — |
+| 3.1 Add Key Status and Validation | ⬚ Pending | — |
+| 3.2 Add Async Key Validation Functions | ⬚ Pending | — |
+| 3.3 Migrate OpenRouter Key | ⬚ Pending | — |
+| 3.4 Update Main Entry Point | ⬚ Pending | — |
 
 ---
 
-## Subtask 3.1: Create API Keys Service
+## Session Notes
 
-**Completed:** —
-
-### What was done
-<!-- Fill after completing subtask -->
-
-### Difficulties encountered
-<!-- Any challenges, confusion, unexpected issues -->
-
-### Solutions applied
-<!-- How issues were resolved -->
-
-### Key learnings
-<!-- Insights, patterns discovered, gotchas for future -->
-
----
-
-## Subtask 3.2: Migrate OpenRouter Key
-
-**Completed:** —
-
-### What was done
-
-### Difficulties encountered
-
-### Solutions applied
-
-### Key learnings
-
----
-
-## Subtask 3.3: Update Main Entry Point
-
-**Completed:** —
-
-### What was done
-
-### Difficulties encountered
-
-### Solutions applied
-
-### Key learnings
-
----
-
-## Phase Summary
-
-**Phase completed:** —
-
-### Overall learnings
-
-### What went well
-
-### What could be improved
-
-### Recommendations for next phase
+_(To be filled during implementation)_
 
 ---
 

--- a/src/api/api.real.js
+++ b/src/api/api.real.js
@@ -1,6 +1,7 @@
-// api.real.js - Uses OpenRouter for LLM calls (client-side)
+// api.real.js - Uses provider router for LLM calls (client-side)
+// Supports multiple LLM providers via provider-router when feature is enabled
 
-import { callOpenRouter } from './openrouter-client.js';
+import { completion } from './provider-router.js';
 import { logger } from '../utils/logger.js';
 import { getSelectedModel } from '../services/model-service.js';
 import { extractJSON } from '../utils/json-extractor.js';
@@ -211,8 +212,8 @@ ${exclusionSection}
 
 CRITICAL: Respond with ONLY valid JSON. No explanation, no thinking, no markdown. Start your response with { and end with }`;
 
-      // Call OpenRouter
-      const result = await callOpenRouter(apiKey, currentPrompt, {
+      // Call LLM via provider router (handles provider selection and routing)
+      const result = await completion(currentPrompt, {
         maxTokens: 2048,
         temperature: 0.7,
       });
@@ -341,7 +342,8 @@ Requirements:
 
 CRITICAL: Respond with ONLY valid JSON. No explanation, no thinking, no markdown. Start your response with { and end with }`;
 
-      const result = await callOpenRouter(apiKey, currentPrompt, {
+      // Call LLM via provider router
+      const result = await completion(currentPrompt, {
         maxTokens: 500,
         temperature: 0.7,
       });
@@ -430,8 +432,9 @@ Be helpful and encouraging. Write in ${languageName} (${language}).
 Provide only the explanation, no other text.`;
 
   try {
+    // Call LLM via provider router
     // Use higher maxTokens for reasoning models that need tokens for chain-of-thought
-    const result = await callOpenRouter(apiKey, prompt, {
+    const result = await completion(prompt, {
       maxTokens: 500,
       temperature: 0.7,
     });

--- a/src/api/api.real.test.js
+++ b/src/api/api.real.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the dependencies before importing the module
-vi.mock('./openrouter-client.js', () => ({
-  callOpenRouter: vi.fn(),
+vi.mock('./provider-router.js', () => ({
+  completion: vi.fn(),
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -15,7 +15,7 @@ vi.mock('../utils/logger.js', () => ({
 }));
 
 import { generateQuestions, generateExplanation } from './api.real.js';
-import { callOpenRouter } from './openrouter-client.js';
+import { completion } from './provider-router.js';
 
 // Helper to generate mock questions of a specific count
 function generateMockQuestions(count) {
@@ -35,7 +35,7 @@ describe('generateQuestions prompt', () => {
   it('should include guidance for distinct answer options', async () => {
     // Arrange: Mock the API to capture the prompt
     let capturedPrompt = '';
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       capturedPrompt = prompt;
       return {
         text: JSON.stringify({
@@ -56,7 +56,7 @@ describe('generateQuestions prompt', () => {
       };
     });
 
-    // Act: Call the function
+    // Act: Call the function (apiKey param is now ignored, read from settings)
     await generateQuestions('Test Topic', 'middle school', 'fake-api-key');
 
     // Assert: Check that the prompt contains guidance for distinct options
@@ -68,7 +68,7 @@ describe('generateQuestions prompt', () => {
   it('should include previous questions in prompt when provided', async () => {
     // Arrange: Mock the API to capture the prompt
     let capturedPrompt = '';
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       capturedPrompt = prompt;
       return {
         text: JSON.stringify({
@@ -102,7 +102,7 @@ describe('generateQuestions prompt', () => {
   it('should not include exclusion section when no previous questions', async () => {
     // Arrange: Mock the API to capture the prompt
     let capturedPrompt = '';
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       capturedPrompt = prompt;
       return {
         text: JSON.stringify({
@@ -132,7 +132,7 @@ describe('generateQuestions prompt', () => {
 
   it('should use default questionCount of 5 in prompt', async () => {
     let capturedPrompt = '';
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       capturedPrompt = prompt;
       return {
         text: JSON.stringify({
@@ -149,7 +149,7 @@ describe('generateQuestions prompt', () => {
 
   it('should use custom questionCount in prompt', async () => {
     let capturedPrompt = '';
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       capturedPrompt = prompt;
       return {
         text: JSON.stringify({
@@ -165,7 +165,7 @@ describe('generateQuestions prompt', () => {
   });
 
   it('should validate response has correct number of questions', async () => {
-    callOpenRouter.mockImplementation(async () => {
+    completion.mockImplementation(async () => {
       return {
         text: JSON.stringify({
           language: 'EN-US',
@@ -180,7 +180,7 @@ describe('generateQuestions prompt', () => {
   });
 
   it('should accept response with matching questionCount', async () => {
-    callOpenRouter.mockImplementation(async () => {
+    completion.mockImplementation(async () => {
       return {
         text: JSON.stringify({
           language: 'EN-US',
@@ -208,7 +208,7 @@ describe('generateExplanation JSON parsing', () => {
   };
 
   it('should parse clean JSON response', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify(validExplanation),
     });
 
@@ -222,7 +222,7 @@ describe('generateExplanation JSON parsing', () => {
   });
 
   it('should parse JSON wrapped in markdown code block', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: '```json\n' + JSON.stringify(validExplanation) + '\n```',
     });
 
@@ -236,7 +236,7 @@ describe('generateExplanation JSON parsing', () => {
   });
 
   it('should parse JSON with leading/trailing whitespace', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: '  \n\n' + JSON.stringify(validExplanation) + '\n\n  ',
     });
 
@@ -255,7 +255,7 @@ describe('generateExplanation JSON parsing', () => {
     const jsonWithSmartQuotes =
       '{ "rightAnswerExplanation": "Paris is correct.", "wrongAnswerExplanation": "London is wrong." }';
 
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: jsonWithSmartQuotes,
     });
 
@@ -274,7 +274,7 @@ describe('generateExplanation JSON parsing', () => {
 
   it('should parse JSON with extra text before it', async () => {
     // Some LLMs add conversational text before the JSON
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: 'Here is the explanation:\n' + JSON.stringify(validExplanation),
     });
 
@@ -290,7 +290,7 @@ describe('generateExplanation JSON parsing', () => {
   });
 
   it('should parse JSON with extra text after it', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify(validExplanation) + '\n\nI hope this helps!',
     });
 
@@ -308,7 +308,7 @@ describe('generateExplanation JSON parsing', () => {
   it('should handle JSON with BOM character', async () => {
     // BOM (Byte Order Mark) can appear at the start of some text
     const BOM = '\uFEFF';
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: BOM + JSON.stringify(validExplanation),
     });
 
@@ -338,7 +338,7 @@ describe('generateQuestions retry logic', () => {
   }
 
   it('should succeed on first attempt when response is valid', async () => {
-    callOpenRouter.mockResolvedValueOnce({
+    completion.mockResolvedValueOnce({
       text: JSON.stringify({ language: 'en', questions: generateValidQuestions(5) }),
       model: 'test-model',
       usage: { promptTokens: 100, completionTokens: 200, totalTokens: 300 },
@@ -347,12 +347,12 @@ describe('generateQuestions retry logic', () => {
     const result = await generateQuestions('Test', 'middle school', 'fake-key');
 
     expect(result.questions).toHaveLength(5);
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 
   it('should retry with stricter prompt on parse failure', async () => {
     let callCount = 0;
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       callCount++;
       if (callCount === 1) {
         // First call: return invalid response
@@ -369,15 +369,15 @@ describe('generateQuestions retry logic', () => {
     const result = await generateQuestions('Test', 'middle school', 'fake-key');
 
     expect(result.questions).toHaveLength(5);
-    expect(callOpenRouter).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledTimes(2);
     // Second call should have stricter prompt
-    const secondCallPrompt = callOpenRouter.mock.calls[1][1];
+    const secondCallPrompt = completion.mock.calls[1][0];
     expect(secondCallPrompt).toContain('CRITICAL: Respond with ONLY valid JSON');
   });
 
   it('should retry on schema validation failure', async () => {
     let callCount = 0;
-    callOpenRouter.mockImplementation(async () => {
+    completion.mockImplementation(async () => {
       callCount++;
       if (callCount === 1) {
         // First call: return JSON with missing 'correct' field
@@ -401,31 +401,31 @@ describe('generateQuestions retry logic', () => {
     const result = await generateQuestions('Test', 'middle school', 'fake-key');
 
     expect(result.questions).toHaveLength(5);
-    expect(callOpenRouter).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledTimes(2);
   });
 
   it('should NOT retry on rate limit error', async () => {
-    callOpenRouter.mockRejectedValueOnce(new Error('Rate limit exceeded'));
+    completion.mockRejectedValueOnce(new Error('Rate limit exceeded'));
 
     await expect(generateQuestions('Test', 'middle school', 'fake-key')).rejects.toThrow(
       'Rate limit exceeded'
     );
 
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 
   it('should NOT retry on authentication error', async () => {
-    callOpenRouter.mockRejectedValueOnce(new Error('Invalid API key'));
+    completion.mockRejectedValueOnce(new Error('Invalid API key'));
 
     await expect(generateQuestions('Test', 'middle school', 'fake-key')).rejects.toThrow(
       'Invalid API key'
     );
 
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 
   it('should fail after max retry attempts', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: 'Invalid JSON response',
     });
 
@@ -433,11 +433,11 @@ describe('generateQuestions retry logic', () => {
       'Invalid response format from AI'
     );
 
-    expect(callOpenRouter).toHaveBeenCalledTimes(2); // 2 attempts max
+    expect(completion).toHaveBeenCalledTimes(2); // 2 attempts max
   });
 
   it('should handle DeepSeek thinking tags in response', async () => {
-    callOpenRouter.mockResolvedValueOnce({
+    completion.mockResolvedValueOnce({
       text: `<think>Let me create a quiz...</think>${JSON.stringify({ language: 'en', questions: generateValidQuestions(5) })}`,
       model: 'deepseek-r1',
       usage: {},
@@ -446,7 +446,7 @@ describe('generateQuestions retry logic', () => {
     const result = await generateQuestions('Test', 'middle school', 'fake-key');
 
     expect(result.questions).toHaveLength(5);
-    expect(callOpenRouter).toHaveBeenCalledTimes(1); // No retry needed
+    expect(completion).toHaveBeenCalledTimes(1); // No retry needed
   });
 });
 
@@ -456,7 +456,7 @@ describe('generateQuestions schema validation', () => {
   });
 
   it('should reject question missing question text', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({
         language: 'en',
         questions: [
@@ -471,7 +471,7 @@ describe('generateQuestions schema validation', () => {
   });
 
   it('should reject question with wrong number of options', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({
         language: 'en',
         questions: [
@@ -486,7 +486,7 @@ describe('generateQuestions schema validation', () => {
   });
 
   it('should reject question with invalid correct index', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({
         language: 'en',
         questions: [
@@ -501,7 +501,7 @@ describe('generateQuestions schema validation', () => {
   });
 
   it('should reject question with string correct value', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({
         language: 'en',
         questions: [
@@ -516,7 +516,7 @@ describe('generateQuestions schema validation', () => {
   });
 
   it('should accept valid quiz with all required fields', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({
         language: 'en',
         questions: [
@@ -552,7 +552,7 @@ describe('generateExplanation retry logic', () => {
   };
 
   it('should succeed on first attempt when response is valid', async () => {
-    callOpenRouter.mockResolvedValueOnce({
+    completion.mockResolvedValueOnce({
       text: JSON.stringify(validExplanation),
     });
 
@@ -563,12 +563,12 @@ describe('generateExplanation retry logic', () => {
 
     expect(result.rightAnswerExplanation).toBe(validExplanation.rightAnswerExplanation);
     expect(result.wrongAnswerExplanation).toBe(validExplanation.wrongAnswerExplanation);
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 
   it('should retry with stricter prompt on parse failure', async () => {
     let callCount = 0;
-    callOpenRouter.mockImplementation(async (apiKey, prompt) => {
+    completion.mockImplementation(async (prompt) => {
       callCount++;
       if (callCount === 1) {
         return { text: 'This is not JSON at all' };
@@ -582,14 +582,14 @@ describe('generateExplanation retry logic', () => {
     });
 
     expect(result.rightAnswerExplanation).toBe(validExplanation.rightAnswerExplanation);
-    expect(callOpenRouter).toHaveBeenCalledTimes(2);
-    const secondCallPrompt = callOpenRouter.mock.calls[1][1];
+    expect(completion).toHaveBeenCalledTimes(2);
+    const secondCallPrompt = completion.mock.calls[1][0];
     expect(secondCallPrompt).toContain('CRITICAL: Respond with ONLY valid JSON');
   });
 
   it('should retry on schema validation failure', async () => {
     let callCount = 0;
-    callOpenRouter.mockImplementation(async () => {
+    completion.mockImplementation(async () => {
       callCount++;
       if (callCount === 1) {
         // Missing wrongAnswerExplanation
@@ -604,11 +604,11 @@ describe('generateExplanation retry logic', () => {
     });
 
     expect(result.rightAnswerExplanation).toBe(validExplanation.rightAnswerExplanation);
-    expect(callOpenRouter).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledTimes(2);
   });
 
   it('should NOT retry on rate limit error', async () => {
-    callOpenRouter.mockRejectedValueOnce(new Error('Rate limit exceeded'));
+    completion.mockRejectedValueOnce(new Error('Rate limit exceeded'));
 
     await expect(
       generateExplanation('What is the capital?', 'London', 'Paris', {
@@ -617,11 +617,11 @@ describe('generateExplanation retry logic', () => {
       })
     ).rejects.toThrow('Rate limit exceeded');
 
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 
   it('should fail after max retry attempts', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: 'Invalid JSON response',
     });
 
@@ -632,11 +632,11 @@ describe('generateExplanation retry logic', () => {
       })
     ).rejects.toThrow('Invalid response format from AI');
 
-    expect(callOpenRouter).toHaveBeenCalledTimes(2);
+    expect(completion).toHaveBeenCalledTimes(2);
   });
 
   it('should handle DeepSeek thinking tags in response', async () => {
-    callOpenRouter.mockResolvedValueOnce({
+    completion.mockResolvedValueOnce({
       text: `<think>Let me explain this...</think>${JSON.stringify(validExplanation)}`,
     });
 
@@ -646,7 +646,7 @@ describe('generateExplanation retry logic', () => {
     });
 
     expect(result.rightAnswerExplanation).toBe(validExplanation.rightAnswerExplanation);
-    expect(callOpenRouter).toHaveBeenCalledTimes(1);
+    expect(completion).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -656,7 +656,7 @@ describe('generateExplanation schema validation', () => {
   });
 
   it('should reject response missing rightAnswerExplanation', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({ wrongAnswerExplanation: 'Something' }),
     });
 
@@ -666,7 +666,7 @@ describe('generateExplanation schema validation', () => {
   });
 
   it('should reject response missing wrongAnswerExplanation', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({ rightAnswerExplanation: 'Something' }),
     });
 
@@ -676,7 +676,7 @@ describe('generateExplanation schema validation', () => {
   });
 
   it('should reject empty rightAnswerExplanation', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({ rightAnswerExplanation: '', wrongAnswerExplanation: 'Something' }),
     });
 
@@ -686,7 +686,7 @@ describe('generateExplanation schema validation', () => {
   });
 
   it('should reject empty wrongAnswerExplanation', async () => {
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify({ rightAnswerExplanation: 'Something', wrongAnswerExplanation: '  ' }),
     });
 
@@ -701,7 +701,7 @@ describe('generateExplanation schema validation', () => {
       wrongAnswerExplanation: 'Your answer was incorrect because...',
     };
 
-    callOpenRouter.mockResolvedValue({
+    completion.mockResolvedValue({
       text: JSON.stringify(validExplanation),
     });
 

--- a/src/api/provider-router.js
+++ b/src/api/provider-router.js
@@ -1,0 +1,180 @@
+/**
+ * Provider Router
+ * Routes LLM calls to appropriate provider (direct or via proxy)
+ *
+ * OpenRouter: Direct browser call (CORS supported)
+ * Other providers: Route through backend proxy (no CORS)
+ */
+
+import { callOpenRouter } from './openrouter-client.js';
+import { supportsCors, getDefaultModel } from './providers-config.js';
+import {
+  getActiveProvider,
+  getActiveModel,
+  getProviderKey,
+} from '../services/provider-settings-service.js';
+import { logger } from '../utils/logger.js';
+import { isFeatureEnabled } from '../core/features.js';
+
+const LLM_PROXY_URL = 'https://saberloop.com/llm/completion.php';
+
+/**
+ * Make an LLM completion request using the active provider
+ * This is the main entry point for all LLM calls when multi-provider feature is enabled.
+ *
+ * @param {string} prompt - The prompt to send to the LLM
+ * @param {object} options - Request options
+ * @param {number} [options.maxTokens=2048] - Maximum tokens in response
+ * @param {number} [options.temperature=0.7] - Temperature for generation
+ * @returns {Promise<{text: string, model: string, provider: string, usage: object}>}
+ */
+export async function completion(prompt, options = {}) {
+  // If feature disabled, use OpenRouter directly (existing behavior)
+  if (!isFeatureEnabled('MULTI_PROVIDER_LLM')) {
+    return await callOpenRouterLegacy(prompt, options);
+  }
+
+  const providerId = await getActiveProvider();
+  let modelId = await getActiveModel();
+  const apiKey = await getProviderKey(providerId);
+
+  // If no model selected, use provider default
+  if (!modelId) {
+    modelId = getDefaultModel(providerId);
+  }
+
+  if (!apiKey) {
+    throw new Error(`No API key configured for ${providerId}`);
+  }
+
+  logger.debug('LLM request via provider router', { provider: providerId, model: modelId });
+
+  if (supportsCors(providerId)) {
+    // Direct call (OpenRouter only)
+    return await callDirect(providerId, apiKey, prompt, modelId, options);
+  } else {
+    // Via backend proxy (OpenAI, Anthropic, Google, xAI)
+    return await callViaProxy(providerId, apiKey, prompt, modelId, options);
+  }
+}
+
+/**
+ * Legacy OpenRouter call - used when MULTI_PROVIDER_LLM feature is disabled
+ * This maintains backward compatibility with existing behavior.
+ *
+ * @param {string} prompt - The prompt to send
+ * @param {object} options - Request options
+ * @returns {Promise<{text: string, model: string, provider: string, usage: object}>}
+ */
+async function callOpenRouterLegacy(prompt, options = {}) {
+  const apiKey = await getProviderKey('openrouter');
+
+  if (!apiKey) {
+    throw new Error('No OpenRouter API key configured');
+  }
+
+  const result = await callOpenRouter(apiKey, prompt, {
+    maxTokens: options.maxTokens || 2048,
+    temperature: options.temperature || 0.7,
+  });
+
+  return {
+    text: result.text,
+    model: result.model,
+    provider: 'openrouter',
+    usage: result.usage,
+  };
+}
+
+/**
+ * Direct call to provider (OpenRouter only - has CORS support)
+ *
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key
+ * @param {string} prompt - Prompt to send
+ * @param {string} modelId - Model ID
+ * @param {object} options - Request options
+ * @returns {Promise<{text: string, model: string, provider: string, usage: object}>}
+ */
+async function callDirect(providerId, apiKey, prompt, modelId, options) {
+  if (providerId !== 'openrouter') {
+    throw new Error(`Direct calls not supported for ${providerId}`);
+  }
+
+  const result = await callOpenRouter(apiKey, prompt, {
+    model: modelId,
+    maxTokens: options.maxTokens || 2048,
+    temperature: options.temperature || 0.7,
+  });
+
+  return {
+    text: result.text,
+    model: result.model,
+    provider: 'openrouter',
+    usage: result.usage,
+  };
+}
+
+/**
+ * Call via backend proxy (OpenAI, Anthropic, Google, xAI)
+ * These providers don't support CORS, so we route through our backend.
+ *
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key
+ * @param {string} prompt - Prompt to send
+ * @param {string} modelId - Model ID
+ * @param {object} options - Request options
+ * @returns {Promise<{text: string, model: string, provider: string, usage: object}>}
+ */
+async function callViaProxy(providerId, apiKey, prompt, modelId, options) {
+  logger.debug('Calling LLM proxy', { provider: providerId, model: modelId });
+
+  const response = await fetch(LLM_PROXY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      provider: providerId,
+      api_key: apiKey,
+      model: modelId,
+      messages: [{ role: 'user', content: prompt }],
+      options: {
+        max_tokens: options.maxTokens || 2048,
+        temperature: options.temperature || 0.7,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ error: `Provider error: ${response.status}` }));
+    logger.error('LLM proxy error', { status: response.status, error: error.error });
+    throw new Error(error.error || `Provider error: ${response.status}`);
+  }
+
+  const result = await response.json();
+
+  logger.debug('LLM proxy response received', {
+    provider: result.provider,
+    model: result.model,
+  });
+
+  return {
+    text: result.text,
+    model: result.model,
+    provider: result.provider,
+    usage: result.usage || {},
+  };
+}
+
+/**
+ * Get the current active provider and model info (for UI display)
+ * @returns {Promise<{providerId: string, modelId: string|null}>}
+ */
+export async function getActiveProviderInfo() {
+  const providerId = await getActiveProvider();
+  const modelId = await getActiveModel();
+  return { providerId, modelId };
+}

--- a/src/api/provider-router.test.js
+++ b/src/api/provider-router.test.js
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { completion, getActiveProviderInfo } from './provider-router.js';
+
+// Mock all dependencies
+vi.mock('./openrouter-client.js', () => ({
+  callOpenRouter: vi.fn(),
+}));
+
+vi.mock('./providers-config.js', () => ({
+  supportsCors: vi.fn(),
+  getDefaultModel: vi.fn(),
+}));
+
+vi.mock('../services/provider-settings-service.js', () => ({
+  getActiveProvider: vi.fn(),
+  getActiveModel: vi.fn(),
+  getProviderKey: vi.fn(),
+}));
+
+vi.mock('../core/features.js', () => ({
+  isFeatureEnabled: vi.fn(),
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { callOpenRouter } from './openrouter-client.js';
+import { supportsCors, getDefaultModel } from './providers-config.js';
+import {
+  getActiveProvider,
+  getActiveModel,
+  getProviderKey,
+} from '../services/provider-settings-service.js';
+import { isFeatureEnabled } from '../core/features.js';
+
+describe('Provider Router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  describe('when feature flag is DISABLED', () => {
+    beforeEach(() => {
+      isFeatureEnabled.mockReturnValue(false);
+    });
+
+    it('should use OpenRouter directly (legacy behavior)', async () => {
+      getProviderKey.mockResolvedValue('sk-or-test-key');
+      callOpenRouter.mockResolvedValue({
+        text: 'Hello from OpenRouter!',
+        model: 'anthropic/claude-3.5-sonnet',
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15, costUsd: 0.001 },
+      });
+
+      const result = await completion('Test prompt');
+
+      expect(isFeatureEnabled).toHaveBeenCalledWith('MULTI_PROVIDER_LLM');
+      expect(callOpenRouter).toHaveBeenCalledWith(
+        'sk-or-test-key',
+        'Test prompt',
+        expect.any(Object)
+      );
+      expect(result.provider).toBe('openrouter');
+      expect(result.text).toBe('Hello from OpenRouter!');
+    });
+
+    it('should throw error when no OpenRouter key configured', async () => {
+      getProviderKey.mockResolvedValue(null);
+
+      await expect(completion('Test prompt')).rejects.toThrow('No OpenRouter API key configured');
+    });
+  });
+
+  describe('when feature flag is ENABLED', () => {
+    beforeEach(() => {
+      isFeatureEnabled.mockReturnValue(true);
+    });
+
+    describe('OpenRouter (direct call)', () => {
+      it('should call OpenRouter directly when selected', async () => {
+        getActiveProvider.mockResolvedValue('openrouter');
+        getActiveModel.mockResolvedValue('anthropic/claude-3.5-sonnet');
+        getProviderKey.mockResolvedValue('sk-or-test-key');
+        supportsCors.mockReturnValue(true);
+
+        callOpenRouter.mockResolvedValue({
+          text: 'Hello!',
+          model: 'anthropic/claude-3.5-sonnet',
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15, costUsd: 0.001 },
+        });
+
+        const result = await completion('Hi');
+
+        expect(supportsCors).toHaveBeenCalledWith('openrouter');
+        expect(callOpenRouter).toHaveBeenCalled();
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result.provider).toBe('openrouter');
+        expect(result.text).toBe('Hello!');
+      });
+
+      it('should use default model when none selected', async () => {
+        getActiveProvider.mockResolvedValue('openrouter');
+        getActiveModel.mockResolvedValue(null);
+        getProviderKey.mockResolvedValue('sk-or-test-key');
+        supportsCors.mockReturnValue(true);
+        getDefaultModel.mockReturnValue('anthropic/claude-3.5-sonnet');
+
+        callOpenRouter.mockResolvedValue({
+          text: 'Hello!',
+          model: 'anthropic/claude-3.5-sonnet',
+          usage: {},
+        });
+
+        await completion('Hi');
+
+        expect(getDefaultModel).toHaveBeenCalledWith('openrouter');
+        expect(callOpenRouter).toHaveBeenCalledWith(
+          'sk-or-test-key',
+          'Hi',
+          expect.objectContaining({ model: 'anthropic/claude-3.5-sonnet' })
+        );
+      });
+    });
+
+    describe('Other providers (via proxy)', () => {
+      it('should call backend proxy for OpenAI', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue('sk-openai-key');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              text: 'Hello from GPT!',
+              model: 'gpt-4o-mini',
+              provider: 'openai',
+              usage: { prompt_tokens: 10, completion_tokens: 5 },
+            }),
+        });
+
+        const result = await completion('Hi');
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/llm/completion.php'),
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+
+        // Verify request body
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.provider).toBe('openai');
+        expect(body.api_key).toBe('sk-openai-key');
+        expect(body.model).toBe('gpt-4o-mini');
+        expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
+
+        expect(callOpenRouter).not.toHaveBeenCalled();
+        expect(result.provider).toBe('openai');
+        expect(result.text).toBe('Hello from GPT!');
+      });
+
+      it('should call backend proxy for Anthropic', async () => {
+        getActiveProvider.mockResolvedValue('anthropic');
+        getActiveModel.mockResolvedValue('claude-sonnet-4-20250514');
+        getProviderKey.mockResolvedValue('sk-ant-test-key');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              text: 'Hello from Claude!',
+              model: 'claude-sonnet-4-20250514',
+              provider: 'anthropic',
+              usage: {},
+            }),
+        });
+
+        const result = await completion('Hi');
+
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.provider).toBe('anthropic');
+        expect(result.provider).toBe('anthropic');
+      });
+
+      it('should call backend proxy for Google', async () => {
+        getActiveProvider.mockResolvedValue('google');
+        getActiveModel.mockResolvedValue('gemini-2.5-flash');
+        getProviderKey.mockResolvedValue('AIza-test-key');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              text: 'Hello from Gemini!',
+              model: 'gemini-2.5-flash',
+              provider: 'google',
+              usage: {},
+            }),
+        });
+
+        const result = await completion('Hi');
+
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.provider).toBe('google');
+        expect(result.provider).toBe('google');
+      });
+
+      it('should call backend proxy for xAI', async () => {
+        getActiveProvider.mockResolvedValue('xai');
+        getActiveModel.mockResolvedValue('grok-3-fast');
+        getProviderKey.mockResolvedValue('xai-test-key');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              text: 'Hello from Grok!',
+              model: 'grok-3-fast',
+              provider: 'xai',
+              usage: {},
+            }),
+        });
+
+        const result = await completion('Hi');
+
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.provider).toBe('xai');
+        expect(result.provider).toBe('xai');
+      });
+    });
+
+    describe('Error handling', () => {
+      it('should throw error when no API key configured', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue(null);
+
+        await expect(completion('Hi')).rejects.toThrow('No API key configured for openai');
+      });
+
+      it('should throw error when proxy returns error', async () => {
+        getActiveProvider.mockResolvedValue('anthropic');
+        getActiveModel.mockResolvedValue('claude-3.5-sonnet');
+        getProviderKey.mockResolvedValue('sk-ant-test');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: false,
+          status: 401,
+          json: () => Promise.resolve({ error: 'Invalid API key' }),
+        });
+
+        await expect(completion('Hi')).rejects.toThrow('Invalid API key');
+      });
+
+      it('should handle proxy returning unknown error', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue('sk-test');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: () => Promise.reject(new Error('Not JSON')),
+        });
+
+        // When JSON parsing fails, we fall back to status code in the error message
+        await expect(completion('Hi')).rejects.toThrow('Provider error: 500');
+      });
+
+      it('should throw error for direct call to non-OpenRouter provider', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue('sk-test');
+        // Incorrectly return true for non-OpenRouter
+        supportsCors.mockReturnValue(true);
+
+        await expect(completion('Hi')).rejects.toThrow('Direct calls not supported for openai');
+      });
+    });
+
+    describe('Options handling', () => {
+      it('should pass maxTokens and temperature options', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue('sk-test');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ text: 'OK', model: 'gpt-4o-mini', provider: 'openai' }),
+        });
+
+        await completion('Hi', { maxTokens: 500, temperature: 0.5 });
+
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.options.max_tokens).toBe(500);
+        expect(body.options.temperature).toBe(0.5);
+      });
+
+      it('should use default options when not provided', async () => {
+        getActiveProvider.mockResolvedValue('openai');
+        getActiveModel.mockResolvedValue('gpt-4o-mini');
+        getProviderKey.mockResolvedValue('sk-test');
+        supportsCors.mockReturnValue(false);
+
+        global.fetch.mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ text: 'OK', model: 'gpt-4o-mini', provider: 'openai' }),
+        });
+
+        await completion('Hi');
+
+        const fetchCall = global.fetch.mock.calls[0];
+        const body = JSON.parse(fetchCall[1].body);
+        expect(body.options.max_tokens).toBe(2048);
+        expect(body.options.temperature).toBe(0.7);
+      });
+    });
+  });
+
+  describe('getActiveProviderInfo', () => {
+    it('should return current provider and model', async () => {
+      getActiveProvider.mockResolvedValue('anthropic');
+      getActiveModel.mockResolvedValue('claude-sonnet-4-20250514');
+
+      const info = await getActiveProviderInfo();
+
+      expect(info.providerId).toBe('anthropic');
+      expect(info.modelId).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('should return null model when not set', async () => {
+      getActiveProvider.mockResolvedValue('openrouter');
+      getActiveModel.mockResolvedValue(null);
+
+      const info = await getActiveProviderInfo();
+
+      expect(info.providerId).toBe('openrouter');
+      expect(info.modelId).toBeNull();
+    });
+  });
+});

--- a/src/api/providers-config.js
+++ b/src/api/providers-config.js
@@ -1,0 +1,209 @@
+/**
+ * Provider configuration
+ * Defines supported LLM providers and their properties
+ */
+
+export const PROVIDERS = {
+  openrouter: {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    description: 'Access multiple AI models via OpenRouter',
+    cors: true, // Can call directly from browser
+    keyPrefix: 'sk-or-',
+    keyPattern: /^sk-or-v1-[a-zA-Z0-9]+$/,
+    docsUrl: 'https://openrouter.ai/keys',
+    models: [
+      {
+        id: 'anthropic/claude-3.5-sonnet',
+        name: 'Claude 3.5 Sonnet',
+        inputPrice: 3.0,
+        outputPrice: 15.0,
+      },
+      { id: 'openai/gpt-4o', name: 'GPT-4o', inputPrice: 2.5, outputPrice: 10.0 },
+      { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', inputPrice: 0.15, outputPrice: 0.6 },
+      {
+        id: 'google/gemini-2.0-flash-exp:free',
+        name: 'Gemini 2.0 Flash (Free)',
+        inputPrice: 0,
+        outputPrice: 0,
+      },
+      {
+        id: 'meta-llama/llama-3.1-70b-instruct:free',
+        name: 'Llama 3.1 70B (Free)',
+        inputPrice: 0,
+        outputPrice: 0,
+      },
+    ],
+    defaultModel: 'anthropic/claude-3.5-sonnet',
+  },
+
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    description: 'Direct access to GPT models',
+    cors: false, // Requires backend proxy
+    keyPrefix: 'sk-',
+    keyPattern: /^sk-[a-zA-Z0-9]+$/,
+    docsUrl: 'https://platform.openai.com/api-keys',
+    models: [
+      { id: 'gpt-4o', name: 'GPT-4o', inputPrice: 2.5, outputPrice: 10.0 },
+      { id: 'gpt-4o-mini', name: 'GPT-4o Mini', inputPrice: 0.15, outputPrice: 0.6 },
+      { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', inputPrice: 10.0, outputPrice: 30.0 },
+      { id: 'o1-preview', name: 'O1 Preview', inputPrice: 15.0, outputPrice: 60.0 },
+    ],
+    defaultModel: 'gpt-4o-mini',
+  },
+
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    description: 'Direct access to Claude models',
+    cors: false,
+    keyPrefix: 'sk-ant-',
+    keyPattern: /^sk-ant-[a-zA-Z0-9-]+$/,
+    docsUrl: 'https://console.anthropic.com/settings/keys',
+    models: [
+      {
+        id: 'claude-sonnet-4-20250514',
+        name: 'Claude Sonnet 4',
+        inputPrice: 3.0,
+        outputPrice: 15.0,
+      },
+      {
+        id: 'claude-3-5-sonnet-20241022',
+        name: 'Claude 3.5 Sonnet',
+        inputPrice: 3.0,
+        outputPrice: 15.0,
+      },
+      {
+        id: 'claude-3-opus-20240229',
+        name: 'Claude 3 Opus',
+        inputPrice: 15.0,
+        outputPrice: 75.0,
+      },
+      {
+        id: 'claude-3-haiku-20240307',
+        name: 'Claude 3 Haiku',
+        inputPrice: 0.25,
+        outputPrice: 1.25,
+      },
+    ],
+    defaultModel: 'claude-sonnet-4-20250514',
+  },
+
+  google: {
+    id: 'google',
+    name: 'Google AI',
+    description: 'Direct access to Gemini models',
+    cors: false,
+    keyPrefix: 'AIza',
+    keyPattern: /^AIza[a-zA-Z0-9_-]+$/,
+    docsUrl: 'https://aistudio.google.com/apikey',
+    freeTier: true,
+    models: [
+      {
+        id: 'gemini-2.5-flash',
+        name: 'Gemini 2.5 Flash',
+        inputPrice: 0.075,
+        outputPrice: 0.3,
+      },
+      { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', inputPrice: 1.25, outputPrice: 5.0 },
+      {
+        id: 'gemini-1.5-flash',
+        name: 'Gemini 1.5 Flash',
+        inputPrice: 0.075,
+        outputPrice: 0.3,
+      },
+    ],
+    defaultModel: 'gemini-2.5-flash',
+  },
+
+  xai: {
+    id: 'xai',
+    name: 'xAI',
+    description: 'Direct access to Grok models',
+    cors: false,
+    keyPrefix: 'xai-',
+    keyPattern: /^xai-[a-zA-Z0-9]+$/,
+    docsUrl: 'https://console.x.ai',
+    models: [
+      { id: 'grok-3-fast', name: 'Grok 3 Fast', inputPrice: 0.2, outputPrice: 0.5 },
+      { id: 'grok-3', name: 'Grok 3', inputPrice: 3.0, outputPrice: 15.0 },
+    ],
+    defaultModel: 'grok-3-fast',
+  },
+};
+
+/**
+ * Get provider by ID
+ * @param {string} providerId - Provider ID
+ * @returns {object|null} Provider configuration or null if not found
+ */
+export function getProvider(providerId) {
+  return PROVIDERS[providerId] || null;
+}
+
+/**
+ * Get all providers
+ * @returns {object[]} Array of all provider configurations
+ */
+export function getAllProviders() {
+  return Object.values(PROVIDERS);
+}
+
+/**
+ * Check if provider supports direct browser calls (CORS)
+ * @param {string} providerId - Provider ID
+ * @returns {boolean} True if provider supports CORS
+ */
+export function supportsCors(providerId) {
+  const provider = getProvider(providerId);
+  return provider?.cors ?? false;
+}
+
+/**
+ * Validate API key format for a provider
+ * @param {string} providerId - Provider ID
+ * @param {string} key - API key to validate
+ * @returns {boolean} True if key format is valid
+ */
+export function validateKeyFormat(providerId, key) {
+  const provider = getProvider(providerId);
+  if (!provider) return false;
+  return provider.keyPattern.test(key);
+}
+
+/**
+ * Calculate estimated cost for a request
+ * @param {string} providerId - Provider ID
+ * @param {string} modelId - Model ID
+ * @param {number} inputTokens - Number of input tokens
+ * @param {number} outputTokens - Number of output tokens
+ * @returns {object|null} Cost breakdown or null if provider/model not found
+ */
+export function estimateCost(providerId, modelId, inputTokens, outputTokens) {
+  const provider = getProvider(providerId);
+  if (!provider) return null;
+
+  const model = provider.models.find((m) => m.id === modelId);
+  if (!model) return null;
+
+  const inputCost = (inputTokens / 1_000_000) * model.inputPrice;
+  const outputCost = (outputTokens / 1_000_000) * model.outputPrice;
+
+  return {
+    inputCost,
+    outputCost,
+    totalCost: inputCost + outputCost,
+  };
+}
+
+/**
+ * Get default model for a provider
+ * @param {string} providerId - Provider ID
+ * @returns {string|null} Default model ID or null if provider not found
+ */
+export function getDefaultModel(providerId) {
+  const provider = getProvider(providerId);
+  return provider?.defaultModel || null;
+}

--- a/src/api/providers-config.test.js
+++ b/src/api/providers-config.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROVIDERS,
+  getProvider,
+  getAllProviders,
+  supportsCors,
+  validateKeyFormat,
+  estimateCost,
+  getDefaultModel,
+} from './providers-config.js';
+
+describe('Providers Config', () => {
+  describe('PROVIDERS constant', () => {
+    it('should have all expected providers', () => {
+      expect(PROVIDERS).toHaveProperty('openrouter');
+      expect(PROVIDERS).toHaveProperty('openai');
+      expect(PROVIDERS).toHaveProperty('anthropic');
+      expect(PROVIDERS).toHaveProperty('google');
+      expect(PROVIDERS).toHaveProperty('xai');
+    });
+
+    it('should have required properties for each provider', () => {
+      const requiredProps = [
+        'id',
+        'name',
+        'description',
+        'cors',
+        'keyPrefix',
+        'keyPattern',
+        'docsUrl',
+        'models',
+        'defaultModel',
+      ];
+
+      Object.values(PROVIDERS).forEach((provider) => {
+        requiredProps.forEach((prop) => {
+          expect(provider).toHaveProperty(prop);
+        });
+      });
+    });
+
+    it('should have at least one model for each provider', () => {
+      Object.values(PROVIDERS).forEach((provider) => {
+        expect(provider.models.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('getProvider', () => {
+    it('should return provider by ID', () => {
+      const provider = getProvider('openai');
+      expect(provider).not.toBeNull();
+      expect(provider.name).toBe('OpenAI');
+    });
+
+    it('should return openrouter provider', () => {
+      const provider = getProvider('openrouter');
+      expect(provider).not.toBeNull();
+      expect(provider.name).toBe('OpenRouter');
+    });
+
+    it('should return null for unknown provider', () => {
+      expect(getProvider('unknown')).toBeNull();
+      expect(getProvider('')).toBeNull();
+      expect(getProvider(null)).toBeNull();
+    });
+  });
+
+  describe('getAllProviders', () => {
+    it('should return all providers as array', () => {
+      const providers = getAllProviders();
+      expect(Array.isArray(providers)).toBe(true);
+      expect(providers.length).toBe(5);
+    });
+
+    it('should include all provider IDs', () => {
+      const providers = getAllProviders();
+      const ids = providers.map((p) => p.id);
+      expect(ids).toContain('openrouter');
+      expect(ids).toContain('openai');
+      expect(ids).toContain('anthropic');
+      expect(ids).toContain('google');
+      expect(ids).toContain('xai');
+    });
+  });
+
+  describe('supportsCors', () => {
+    it('should return true for OpenRouter', () => {
+      expect(supportsCors('openrouter')).toBe(true);
+    });
+
+    it('should return false for other providers', () => {
+      expect(supportsCors('openai')).toBe(false);
+      expect(supportsCors('anthropic')).toBe(false);
+      expect(supportsCors('google')).toBe(false);
+      expect(supportsCors('xai')).toBe(false);
+    });
+
+    it('should return false for unknown provider', () => {
+      expect(supportsCors('unknown')).toBe(false);
+    });
+  });
+
+  describe('validateKeyFormat', () => {
+    describe('OpenRouter', () => {
+      it('should validate correct OpenRouter key format', () => {
+        expect(validateKeyFormat('openrouter', 'sk-or-v1-abc123')).toBe(true);
+        expect(validateKeyFormat('openrouter', 'sk-or-v1-ABC123xyz')).toBe(true);
+      });
+
+      it('should reject invalid OpenRouter key format', () => {
+        expect(validateKeyFormat('openrouter', 'invalid')).toBe(false);
+        expect(validateKeyFormat('openrouter', 'sk-or-abc123')).toBe(false);
+        expect(validateKeyFormat('openrouter', 'sk-abc123')).toBe(false);
+      });
+    });
+
+    describe('OpenAI', () => {
+      it('should validate correct OpenAI key format', () => {
+        expect(validateKeyFormat('openai', 'sk-abc123')).toBe(true);
+        expect(validateKeyFormat('openai', 'sk-ABC123xyz789')).toBe(true);
+      });
+
+      it('should reject invalid OpenAI key format', () => {
+        expect(validateKeyFormat('openai', 'invalid')).toBe(false);
+        expect(validateKeyFormat('openai', 'abc123')).toBe(false);
+      });
+    });
+
+    describe('Anthropic', () => {
+      it('should validate correct Anthropic key format', () => {
+        expect(validateKeyFormat('anthropic', 'sk-ant-abc123')).toBe(true);
+        expect(validateKeyFormat('anthropic', 'sk-ant-ABC-123-xyz')).toBe(true);
+      });
+
+      it('should reject invalid Anthropic key format', () => {
+        expect(validateKeyFormat('anthropic', 'invalid')).toBe(false);
+        expect(validateKeyFormat('anthropic', 'sk-abc123')).toBe(false);
+      });
+    });
+
+    describe('Google', () => {
+      it('should validate correct Google key format', () => {
+        expect(validateKeyFormat('google', 'AIzaABC123xyz')).toBe(true);
+        expect(validateKeyFormat('google', 'AIza_test-key_123')).toBe(true);
+      });
+
+      it('should reject invalid Google key format', () => {
+        expect(validateKeyFormat('google', 'invalid')).toBe(false);
+        expect(validateKeyFormat('google', 'AIza')).toBe(false);
+      });
+    });
+
+    describe('xAI', () => {
+      it('should validate correct xAI key format', () => {
+        expect(validateKeyFormat('xai', 'xai-abc123')).toBe(true);
+        expect(validateKeyFormat('xai', 'xai-ABC123xyz')).toBe(true);
+      });
+
+      it('should reject invalid xAI key format', () => {
+        expect(validateKeyFormat('xai', 'invalid')).toBe(false);
+        expect(validateKeyFormat('xai', 'xai-')).toBe(false);
+      });
+    });
+
+    it('should return false for unknown provider', () => {
+      expect(validateKeyFormat('unknown', 'anykey')).toBe(false);
+    });
+  });
+
+  describe('estimateCost', () => {
+    it('should calculate cost correctly for OpenAI gpt-4o-mini', () => {
+      // gpt-4o-mini: inputPrice: 0.15, outputPrice: 0.6 per 1M tokens
+      const cost = estimateCost('openai', 'gpt-4o-mini', 1000, 500);
+
+      // Input: 1000 / 1,000,000 * 0.15 = 0.00015
+      expect(cost.inputCost).toBeCloseTo(0.00015, 6);
+
+      // Output: 500 / 1,000,000 * 0.6 = 0.0003
+      expect(cost.outputCost).toBeCloseTo(0.0003, 6);
+
+      // Total: 0.00015 + 0.0003 = 0.00045
+      expect(cost.totalCost).toBeCloseTo(0.00045, 6);
+    });
+
+    it('should calculate cost correctly for free models', () => {
+      const cost = estimateCost('openrouter', 'google/gemini-2.0-flash-exp:free', 10000, 5000);
+
+      expect(cost.inputCost).toBe(0);
+      expect(cost.outputCost).toBe(0);
+      expect(cost.totalCost).toBe(0);
+    });
+
+    it('should return null for unknown provider', () => {
+      expect(estimateCost('unknown', 'some-model', 1000, 500)).toBeNull();
+    });
+
+    it('should return null for unknown model', () => {
+      expect(estimateCost('openai', 'unknown-model', 1000, 500)).toBeNull();
+    });
+  });
+
+  describe('getDefaultModel', () => {
+    it('should return default model for openrouter', () => {
+      expect(getDefaultModel('openrouter')).toBe('anthropic/claude-3.5-sonnet');
+    });
+
+    it('should return default model for openai', () => {
+      expect(getDefaultModel('openai')).toBe('gpt-4o-mini');
+    });
+
+    it('should return default model for anthropic', () => {
+      expect(getDefaultModel('anthropic')).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('should return default model for google', () => {
+      expect(getDefaultModel('google')).toBe('gemini-2.5-flash');
+    });
+
+    it('should return default model for xai', () => {
+      expect(getDefaultModel('xai')).toBe('grok-3-fast');
+    });
+
+    it('should return null for unknown provider', () => {
+      expect(getDefaultModel('unknown')).toBeNull();
+    });
+  });
+});

--- a/src/core/features.js
+++ b/src/core/features.js
@@ -12,6 +12,10 @@ export const FEATURE_FLAGS = {
     phase: 'ENABLED', // Show AdSense ads during loading screens
     description: 'Display Google AdSense ads during quiz and results loading',
   },
+  MULTI_PROVIDER_LLM: {
+    phase: 'DISABLED', // Start disabled for safe deployment
+    description: 'Allow users to configure and use multiple LLM providers',
+  },
 };
 
 /**

--- a/src/services/provider-settings-service.js
+++ b/src/services/provider-settings-service.js
@@ -1,0 +1,125 @@
+/**
+ * Provider Settings Service
+ * Manages active provider selection and API keys for LLM providers
+ */
+
+import { getSetting, saveSetting, getOpenRouterKey } from '../core/db.js';
+
+const SETTINGS_KEYS = {
+  ACTIVE_PROVIDER: 'llm_active_provider',
+  ACTIVE_MODEL: 'llm_active_model',
+  PROVIDER_KEY_PREFIX: 'llm_key_',
+};
+
+const DEFAULT_PROVIDER = 'openrouter';
+
+/**
+ * Get active provider ID
+ * @returns {Promise<string>} Active provider ID (defaults to 'openrouter')
+ */
+export async function getActiveProvider() {
+  const providerId = await getSetting(SETTINGS_KEYS.ACTIVE_PROVIDER);
+  return providerId || DEFAULT_PROVIDER;
+}
+
+/**
+ * Set active provider
+ * @param {string} providerId - Provider ID to set as active
+ */
+export async function setActiveProvider(providerId) {
+  await saveSetting(SETTINGS_KEYS.ACTIVE_PROVIDER, providerId);
+}
+
+/**
+ * Get active model for current provider
+ * @returns {Promise<string|null>} Active model ID or null if not set
+ */
+export async function getActiveModel() {
+  return await getSetting(SETTINGS_KEYS.ACTIVE_MODEL);
+}
+
+/**
+ * Set active model
+ * @param {string} modelId - Model ID to set as active
+ */
+export async function setActiveModel(modelId) {
+  await saveSetting(SETTINGS_KEYS.ACTIVE_MODEL, modelId);
+}
+
+/**
+ * Get API key for a provider
+ * @param {string} providerId - Provider ID
+ * @returns {Promise<string|null>} API key or null if not configured
+ */
+export async function getProviderKey(providerId) {
+  // Special case: OpenRouter uses existing storage mechanism
+  if (providerId === 'openrouter') {
+    return await getOpenRouterKey();
+  }
+
+  const key = SETTINGS_KEYS.PROVIDER_KEY_PREFIX + providerId;
+  return await getSetting(key);
+}
+
+/**
+ * Set API key for a provider
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key to store
+ */
+export async function setProviderKey(providerId, apiKey) {
+  // Special case: OpenRouter uses existing storage mechanism
+  // For OpenRouter, use the existing storeOpenRouterKey function from db.js
+  if (providerId === 'openrouter') {
+    // Import dynamically to avoid circular dependency
+    const { storeOpenRouterKey } = await import('../core/db.js');
+    await storeOpenRouterKey(apiKey);
+    return;
+  }
+
+  const key = SETTINGS_KEYS.PROVIDER_KEY_PREFIX + providerId;
+  await saveSetting(key, apiKey);
+}
+
+/**
+ * Remove API key for a provider
+ * @param {string} providerId - Provider ID
+ */
+export async function removeProviderKey(providerId) {
+  // Special case: OpenRouter uses existing storage mechanism
+  if (providerId === 'openrouter') {
+    const { removeOpenRouterKey } = await import('../core/db.js');
+    await removeOpenRouterKey();
+    return;
+  }
+
+  const key = SETTINGS_KEYS.PROVIDER_KEY_PREFIX + providerId;
+  // Remove by setting to null
+  await saveSetting(key, null);
+}
+
+/**
+ * Check if a provider has a key configured
+ * @param {string} providerId - Provider ID
+ * @returns {Promise<boolean>} True if key is configured
+ */
+export async function hasProviderKey(providerId) {
+  const key = await getProviderKey(providerId);
+  return !!key;
+}
+
+/**
+ * Get list of configured providers (with keys)
+ * @returns {Promise<string[]>} Array of provider IDs that have keys configured
+ */
+export async function getConfiguredProviders() {
+  const providers = ['openrouter', 'openai', 'anthropic', 'google', 'xai'];
+  const configured = [];
+
+  for (const providerId of providers) {
+    if (await hasProviderKey(providerId)) {
+      configured.push(providerId);
+    }
+  }
+
+  return configured;
+}

--- a/src/services/provider-settings-service.test.js
+++ b/src/services/provider-settings-service.test.js
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getActiveProvider,
+  setActiveProvider,
+  getActiveModel,
+  setActiveModel,
+  getProviderKey,
+  setProviderKey,
+  removeProviderKey,
+  hasProviderKey,
+  getConfiguredProviders,
+} from './provider-settings-service.js';
+
+// Mock the db module
+vi.mock('../core/db.js', () => ({
+  getSetting: vi.fn(),
+  saveSetting: vi.fn(),
+  getOpenRouterKey: vi.fn(),
+  storeOpenRouterKey: vi.fn(),
+  removeOpenRouterKey: vi.fn(),
+}));
+
+import {
+  getSetting,
+  saveSetting,
+  getOpenRouterKey,
+  storeOpenRouterKey,
+  removeOpenRouterKey,
+} from '../core/db.js';
+
+describe('Provider Settings Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getActiveProvider', () => {
+    it('should return default provider when not set', async () => {
+      getSetting.mockResolvedValue(null);
+      const provider = await getActiveProvider();
+      expect(provider).toBe('openrouter');
+    });
+
+    it('should return stored provider', async () => {
+      getSetting.mockResolvedValue('openai');
+      const provider = await getActiveProvider();
+      expect(provider).toBe('openai');
+    });
+
+    it('should call getSetting with correct key', async () => {
+      getSetting.mockResolvedValue(null);
+      await getActiveProvider();
+      expect(getSetting).toHaveBeenCalledWith('llm_active_provider');
+    });
+  });
+
+  describe('setActiveProvider', () => {
+    it('should store provider in settings', async () => {
+      await setActiveProvider('anthropic');
+      expect(saveSetting).toHaveBeenCalledWith('llm_active_provider', 'anthropic');
+    });
+  });
+
+  describe('getActiveModel', () => {
+    it('should return null when not set', async () => {
+      getSetting.mockResolvedValue(null);
+      const model = await getActiveModel();
+      expect(model).toBeNull();
+    });
+
+    it('should return stored model', async () => {
+      getSetting.mockResolvedValue('gpt-4o-mini');
+      const model = await getActiveModel();
+      expect(model).toBe('gpt-4o-mini');
+    });
+  });
+
+  describe('setActiveModel', () => {
+    it('should store model in settings', async () => {
+      await setActiveModel('claude-3.5-sonnet');
+      expect(saveSetting).toHaveBeenCalledWith('llm_active_model', 'claude-3.5-sonnet');
+    });
+  });
+
+  describe('getProviderKey', () => {
+    it('should use getOpenRouterKey for openrouter provider', async () => {
+      getOpenRouterKey.mockResolvedValue('sk-or-test-key');
+      const key = await getProviderKey('openrouter');
+      expect(getOpenRouterKey).toHaveBeenCalled();
+      expect(key).toBe('sk-or-test-key');
+    });
+
+    it('should return null when openrouter key not stored', async () => {
+      getOpenRouterKey.mockResolvedValue(null);
+      const key = await getProviderKey('openrouter');
+      expect(key).toBeNull();
+    });
+
+    it('should use getSetting for other providers', async () => {
+      getSetting.mockResolvedValue('sk-test-openai-key');
+      const key = await getProviderKey('openai');
+      expect(getSetting).toHaveBeenCalledWith('llm_key_openai');
+      expect(key).toBe('sk-test-openai-key');
+    });
+
+    it('should return null when key not stored', async () => {
+      getSetting.mockResolvedValue(null);
+      const key = await getProviderKey('openai');
+      expect(key).toBeNull();
+    });
+  });
+
+  describe('setProviderKey', () => {
+    it('should use storeOpenRouterKey for openrouter provider', async () => {
+      await setProviderKey('openrouter', 'sk-or-new-key');
+      expect(storeOpenRouterKey).toHaveBeenCalledWith('sk-or-new-key');
+    });
+
+    it('should use saveSetting for other providers', async () => {
+      await setProviderKey('openai', 'sk-new-openai-key');
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_openai', 'sk-new-openai-key');
+    });
+
+    it('should store anthropic key correctly', async () => {
+      await setProviderKey('anthropic', 'sk-ant-test');
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_anthropic', 'sk-ant-test');
+    });
+  });
+
+  describe('removeProviderKey', () => {
+    it('should use removeOpenRouterKey for openrouter provider', async () => {
+      await removeProviderKey('openrouter');
+      expect(removeOpenRouterKey).toHaveBeenCalled();
+    });
+
+    it('should set key to null for other providers', async () => {
+      await removeProviderKey('openai');
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_openai', null);
+    });
+  });
+
+  describe('hasProviderKey', () => {
+    it('should return false when no key', async () => {
+      getOpenRouterKey.mockResolvedValue(null);
+      expect(await hasProviderKey('openrouter')).toBe(false);
+    });
+
+    it('should return true when key exists', async () => {
+      getOpenRouterKey.mockResolvedValue('sk-or-key');
+      expect(await hasProviderKey('openrouter')).toBe(true);
+    });
+
+    it('should return false when other provider key is null', async () => {
+      getSetting.mockResolvedValue(null);
+      expect(await hasProviderKey('openai')).toBe(false);
+    });
+
+    it('should return true when other provider key exists', async () => {
+      getSetting.mockResolvedValue('sk-key');
+      expect(await hasProviderKey('openai')).toBe(true);
+    });
+  });
+
+  describe('getConfiguredProviders', () => {
+    it('should return empty array when no keys configured', async () => {
+      getOpenRouterKey.mockResolvedValue(null);
+      getSetting.mockResolvedValue(null);
+
+      const providers = await getConfiguredProviders();
+      expect(providers).toEqual([]);
+    });
+
+    it('should return list of providers with keys', async () => {
+      getOpenRouterKey.mockResolvedValue('sk-or-key');
+      getSetting.mockImplementation((key) => {
+        if (key === 'llm_key_openai') return Promise.resolve('sk-openai');
+        if (key === 'llm_key_anthropic') return Promise.resolve(null);
+        if (key === 'llm_key_google') return Promise.resolve('AIza-google');
+        if (key === 'llm_key_xai') return Promise.resolve(null);
+        return Promise.resolve(null);
+      });
+
+      const providers = await getConfiguredProviders();
+      expect(providers).toContain('openrouter');
+      expect(providers).toContain('openai');
+      expect(providers).toContain('google');
+      expect(providers).not.toContain('anthropic');
+      expect(providers).not.toContain('xai');
+    });
+  });
+});

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,2 @@
 // Auto-generated - do not edit manually
-export const APP_VERSION = '20260122.454';
+export const APP_VERSION = '20260122.455';

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,2 @@
 // Auto-generated - do not edit manually
-export const APP_VERSION = '20260122.455';
+export const APP_VERSION = '20260122.456';

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,2 @@
 // Auto-generated - do not edit manually
-export const APP_VERSION = '20260122.456';
+export const APP_VERSION = '20260122.457';


### PR DESCRIPTION
## Summary

- Add `MULTI_PROVIDER_LLM` feature flag for gradual rollout
- Create `providers-config.js` with 5 provider configurations (OpenRouter, OpenAI, Anthropic, Google, xAI)
- Create `provider-router.js` to route LLM calls based on CORS support
- Create `provider-settings-service.js` for managing active provider/model and API keys
- Update `api.real.js` to use provider router instead of direct OpenRouter calls

## Key Design Decisions

- **Feature flag**: When DISABLED, uses legacy OpenRouter behavior (backward compatible)
- **CORS routing**: Only OpenRouter supports direct browser calls; others route through backend proxy
- **Settings storage**: Uses `llm_` prefix in IndexedDB, special handling for OpenRouter (existing db.js functions)

## Files Added/Modified

### New Files
- `src/api/providers-config.js` (32 tests)
- `src/api/provider-router.js` (16 tests)
- `src/services/provider-settings-service.js` (22 tests)
- `src/core/features.js` - Added MULTI_PROVIDER_LLM flag
- `docs/learning/epic10_hygiene/FLAG_MULTI_PROVIDER_LLM.md`
- `docs/learning/epic11_llm_support/PHASE2_LEARNING_NOTES.md`

### Modified Files
- `src/api/api.real.js` - Uses `completion()` from provider-router
- `src/api/api.real.test.js` - Updated mocks
- `docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md` - Updated based on Phase 2 learnings

## Test plan

- [x] All 1262 unit tests passing
- [x] All 178 E2E tests passing (regression)
- [x] New provider-config tests (32)
- [x] New provider-router tests (16)
- [x] New provider-settings-service tests (22)

🤖 Generated with [Claude Code](https://claude.ai/code)