### PR TITLE
feat(llm): Phase 3 - Key status tracking and validation

### DIFF
--- a/docs/learning/epic11_llm_support/EPIC11_LLM_SUPPORT_PLAN.md
+++ b/docs/learning/epic11_llm_support/EPIC11_LLM_SUPPORT_PLAN.md
@@ -192,8 +192,8 @@ Update this section after EVERY subtask completion:
 ```
 
 **Current Progress:**
-- **Last checkpoint:** Phase 2 COMPLETE - Frontend provider router implemented
-- **Next action:** Begin Phase 3 - Key Management
+- **Last checkpoint:** Phase 3 COMPLETE - Key status tracking and validation implemented
+- **Next action:** Begin Phase 4 - Settings UI
 - **Blockers:** None
 - **Session:** January 22, 2026
 

--- a/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
+++ b/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
@@ -34,10 +34,10 @@ After completing **ANY** subtask (3.1, 3.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Subtask 3.3 COMPLETE - API key migration created
+- **Last checkpoint:** Phase 3 COMPLETE - All subtasks finished
 - **Current task:** —
-- **Completed:** 3.1, 3.2, 3.3
-- **Next action:** Begin Subtask 3.4 (Update Main Entry Point)
+- **Completed:** 3.1, 3.2, 3.3, 3.4
+- **Next action:** Create PR and merge to main, then begin Phase 4
 - **Blockers:** None
 - **Session:** January 22, 2026
 
@@ -409,7 +409,7 @@ Before starting 3.4, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 3.4 Update Main Entry Point
+### ✅ 3.4 Update Main Entry Point
 
 Add migration call to app initialization.
 

--- a/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
+++ b/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
@@ -34,12 +34,12 @@ After completing **ANY** subtask (3.1, 3.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Not started
+- **Last checkpoint:** Subtask 3.1 COMPLETE - Key status tracking added
 - **Current task:** —
-- **Completed:** —
-- **Next action:** Begin Subtask 3.1 (Create API Keys Service)
+- **Completed:** 3.1
+- **Next action:** Begin Subtask 3.2 (Add Async Key Validation Functions)
 - **Blockers:** None
-- **Session:** —
+- **Session:** January 22, 2026
 
 ---
 
@@ -83,7 +83,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
 ## Tasks
 
-### ⬚ 3.1 Add Key Status and Validation to provider-settings-service.js
+### ✅ 3.1 Add Key Status and Validation to provider-settings-service.js
 
 **File:** `src/services/provider-settings-service.js` (EXTEND existing file from Phase 2)
 

--- a/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
+++ b/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
@@ -34,10 +34,10 @@ After completing **ANY** subtask (3.1, 3.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Subtask 3.2 COMPLETE - Async key validation implemented
+- **Last checkpoint:** Subtask 3.3 COMPLETE - API key migration created
 - **Current task:** —
-- **Completed:** 3.1, 3.2
-- **Next action:** Begin Subtask 3.3 (Migrate OpenRouter Key)
+- **Completed:** 3.1, 3.2, 3.3
+- **Next action:** Begin Subtask 3.4 (Update Main Entry Point)
 - **Blockers:** None
 - **Session:** January 22, 2026
 
@@ -325,7 +325,7 @@ Before starting 3.3, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 3.3 Migrate OpenRouter Key
+### ✅ 3.3 Migrate OpenRouter Key
 
 Handle migration of existing OpenRouter key to trigger validation status.
 

--- a/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
+++ b/docs/learning/epic11_llm_support/PHASE3_KEY_MANAGEMENT.md
@@ -34,10 +34,10 @@ After completing **ANY** subtask (3.1, 3.2, etc.), STOP and complete this checkl
 
 ### Progress Marker
 
-- **Last checkpoint:** Subtask 3.1 COMPLETE - Key status tracking added
+- **Last checkpoint:** Subtask 3.2 COMPLETE - Async key validation implemented
 - **Current task:** —
-- **Completed:** 3.1
-- **Next action:** Begin Subtask 3.2 (Add Async Key Validation Functions)
+- **Completed:** 3.1, 3.2
+- **Next action:** Begin Subtask 3.3 (Migrate OpenRouter Key)
 - **Blockers:** None
 - **Session:** January 22, 2026
 
@@ -226,7 +226,7 @@ Before starting 3.2, complete the [Subtask Completion Checklist](#subtask-comple
 
 ---
 
-### ⬚ 3.2 Add Async Key Validation Functions
+### ✅ 3.2 Add Async Key Validation Functions
 
 **File:** `src/services/provider-settings-service.js` (continue extending)
 

--- a/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
@@ -13,7 +13,7 @@
 |---------|--------|--------------|
 | 3.1 Add Key Status and Validation | ✅ Complete | January 22, 2026 |
 | 3.2 Add Async Key Validation Functions | ✅ Complete | January 22, 2026 |
-| 3.3 Migrate OpenRouter Key | ⬚ Pending | — |
+| 3.3 Migrate OpenRouter Key | ✅ Complete | January 22, 2026 |
 | 3.4 Update Main Entry Point | ⬚ Pending | — |
 
 ---
@@ -75,6 +75,33 @@
 
 #### Next Steps
 - Continue with Subtask 3.3: Migrate OpenRouter Key
+
+---
+
+### Session: January 22, 2026 - Subtask 3.3
+
+#### Completed
+- Created `src/services/api-keys-migration.js` module
+- Implemented `migrateApiKeys()` function that:
+  - Checks migration flag to avoid re-running
+  - Sets `KEY_STATUS.VALID` for existing OpenRouter keys
+  - Migrates legacy keys from localStorage to IndexedDB
+  - Removes legacy localStorage keys after migration
+  - Handles errors gracefully (doesn't fail app startup)
+- Added 7 unit tests covering all migration scenarios
+- All 1301 unit tests pass (no regressions)
+
+#### Difficulties & Solutions
+- **localStorage availability**: Wrapped localStorage access in `typeof` check for SSR/test environments
+- **Error handling**: Migration errors are logged but don't throw - app startup shouldn't fail
+
+#### Learnings
+- Migration modules should be idempotent (safe to run multiple times)
+- Using a flag (`llm_keys_migrated_v1`) ensures migration only runs once
+- Existing OpenRouter keys are assumed valid (they were working before)
+
+#### Next Steps
+- Continue with Subtask 3.4: Wire migration into main.js
 
 ---
 

--- a/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
@@ -2,7 +2,7 @@
 
 **Epic:** 11 - Multi-Provider LLM Support
 **Phase:** 3 - API Key Management
-**Started:** —
+**Started:** January 22, 2026
 **Completed:** —
 
 ---
@@ -11,7 +11,7 @@
 
 | Subtask | Status | Session Date |
 |---------|--------|--------------|
-| 3.1 Add Key Status and Validation | ⬚ Pending | — |
+| 3.1 Add Key Status and Validation | ✅ Complete | January 22, 2026 |
 | 3.2 Add Async Key Validation Functions | ⬚ Pending | — |
 | 3.3 Migrate OpenRouter Key | ⬚ Pending | — |
 | 3.4 Update Main Entry Point | ⬚ Pending | — |
@@ -20,8 +20,35 @@
 
 ## Session Notes
 
-_(To be filled during implementation)_
+### Session: January 22, 2026 - Subtask 3.1
+
+#### Completed
+- Extended `provider-settings-service.js` with key status tracking
+- Added `KEY_STATUS` enum with states: `NOT_SET`, `VALIDATING`, `VALID`, `INVALID`
+- Added `KEY_STATUS_PREFIX` to settings keys (`llm_key_status_`)
+- Implemented new functions:
+  - `getKeyStatus()` - Get validation status for a provider
+  - `getMaskedKey()` - Mask API key for display (e.g., `sk-12...cdef`)
+  - `saveProviderKeyWithValidation()` - Save key with format validation and async validation trigger
+  - `removeProviderKeyWithStatus()` - Remove key and clear status
+  - `getAllProviderStatuses()` - Get all provider statuses for UI
+  - `revalidateKey()` - Trigger re-validation from UI
+- Added placeholder `validateKeyAsync()` (full implementation in 3.2)
+- Added 25+ new unit tests for all new functions
+- All 1287 unit tests pass (no regressions)
+
+#### Difficulties & Solutions
+- **No significant difficulties** - Phase 2 had already established the service structure, making extension straightforward
+- **Note:** The `validateKeyAsync()` function is a placeholder that immediately marks keys as valid. Real validation will be implemented in Subtask 3.2.
+
+#### Learnings
+- The existing `provider-settings-service.js` from Phase 2 provided good scaffolding
+- Separating format validation (sync) from API validation (async) keeps the UX responsive
+- Mock structure in tests needed to be extended for `providers-config.js` and `logger.js`
+
+#### Next Steps
+- Continue with Subtask 3.2: Implement real async key validation functions
 
 ---
 
-*Last Updated: —*
+*Last Updated: January 22, 2026*

--- a/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
@@ -12,7 +12,7 @@
 | Subtask | Status | Session Date |
 |---------|--------|--------------|
 | 3.1 Add Key Status and Validation | ✅ Complete | January 22, 2026 |
-| 3.2 Add Async Key Validation Functions | ⬚ Pending | — |
+| 3.2 Add Async Key Validation Functions | ✅ Complete | January 22, 2026 |
 | 3.3 Migrate OpenRouter Key | ⬚ Pending | — |
 | 3.4 Update Main Entry Point | ⬚ Pending | — |
 
@@ -48,6 +48,33 @@
 
 #### Next Steps
 - Continue with Subtask 3.2: Implement real async key validation functions
+
+---
+
+### Session: January 22, 2026 - Subtask 3.2
+
+#### Completed
+- Replaced placeholder `validateKeyAsync()` with full implementation
+- Added `testProviderKey()` - routes to direct or proxy validation based on CORS support
+- Added `testOpenRouterKey()` - tests OpenRouter keys directly via `/api/v1/auth/key` endpoint
+- Added `testViaProxy()` - tests other provider keys via backend proxy at `saberloop.com/llm/completion.php`
+- Added 7 new integration tests for async validation
+- All 1294 unit tests pass (no regressions)
+
+#### Difficulties & Solutions
+- **Mock configuration issue**: Initial tests failed because the mock `getProvider()` didn't include `defaultModel`
+  - **Fix**: Updated mock to include `defaultModel` for all providers
+- **Async test timing**: Tests needed `setTimeout` to wait for fire-and-forget async validation
+  - **Solution**: Added `await new Promise((resolve) => setTimeout(resolve, 10))` to wait for async status updates
+
+#### Learnings
+- OpenRouter has a dedicated `/api/v1/auth/key` endpoint for key validation (returns key info if valid)
+- Other providers don't have such endpoints, so we use minimal completion requests (5 tokens) to validate
+- Testing async fire-and-forget functions requires careful timing in tests
+- The `supportsCors()` function from providers-config determines the validation path
+
+#### Next Steps
+- Continue with Subtask 3.3: Migrate OpenRouter Key
 
 ---
 

--- a/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
+++ b/docs/learning/epic11_llm_support/PHASE3_LEARNING_NOTES.md
@@ -3,7 +3,7 @@
 **Epic:** 11 - Multi-Provider LLM Support
 **Phase:** 3 - API Key Management
 **Started:** January 22, 2026
-**Completed:** —
+**Completed:** January 22, 2026
 
 ---
 
@@ -14,7 +14,7 @@
 | 3.1 Add Key Status and Validation | ✅ Complete | January 22, 2026 |
 | 3.2 Add Async Key Validation Functions | ✅ Complete | January 22, 2026 |
 | 3.3 Migrate OpenRouter Key | ✅ Complete | January 22, 2026 |
-| 3.4 Update Main Entry Point | ⬚ Pending | — |
+| 3.4 Update Main Entry Point | ✅ Complete | January 22, 2026 |
 
 ---
 
@@ -102,6 +102,58 @@
 
 #### Next Steps
 - Continue with Subtask 3.4: Wire migration into main.js
+
+---
+
+### Session: January 22, 2026 - Subtask 3.4
+
+#### Completed
+- Added import for `migrateApiKeys` to `main.js`
+- Wired migration call in `init()` function, right after database initialization
+- All 1301 unit tests pass
+- All 179 E2E tests pass
+- Phase 3 complete!
+
+#### Difficulties & Solutions
+- **No difficulties** - Simple one-line addition to main.js
+
+#### Learnings
+- Migration should run early in the initialization sequence (after DB, before other features)
+- The migration is idempotent so it's safe to run on every app start
+
+---
+
+## Phase 3 Summary
+
+### What Was Built
+1. **Key Status Tracking** (`provider-settings-service.js`)
+   - `KEY_STATUS` enum for validation states
+   - Status persistence in IndexedDB
+   - `getMaskedKey()` for secure display
+
+2. **Async Key Validation** (`provider-settings-service.js`)
+   - OpenRouter: Direct validation via `/api/v1/auth/key`
+   - Other providers: Validation via backend proxy
+   - Fire-and-forget pattern (doesn't block UI)
+
+3. **API Key Migration** (`api-keys-migration.js`)
+   - Sets initial status for existing OpenRouter keys
+   - Migrates legacy localStorage keys
+   - Runs once on app startup
+
+### Files Created/Modified
+- `src/services/provider-settings-service.js` - Extended with 8 new functions
+- `src/services/provider-settings-service.test.js` - Added 32 new tests
+- `src/services/api-keys-migration.js` - New file
+- `src/services/api-keys-migration.test.js` - New file (7 tests)
+- `src/main.js` - Added migration call
+
+### Test Results
+- Unit tests: 1301 (all pass)
+- E2E tests: 179 (all pass)
+
+### Ready for Phase 4
+The key management service layer is complete. Phase 4 will add the Settings UI to expose these functions to users.
 
 ---
 

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,7 @@ import state from './core/state.js';
 import { initAdManager } from './utils/adManager.js';
 import { initTheme } from './services/theme-manager.js';
 import { showConfirmModal } from './components/ConfirmModal.js';
+import { migrateApiKeys } from './services/api-keys-migration.js';
 
 logger.info('Saberloop initializing');
 initErrorHandling();
@@ -55,6 +56,9 @@ async function init() {
 
     await initDatabase();
     logger.info('Database initialized');
+
+    // Migrate API keys (if needed)
+    await migrateApiKeys();
 
     // Load sample quizzes if needed
     await loadSamplesIfNeeded();

--- a/src/services/api-keys-migration.js
+++ b/src/services/api-keys-migration.js
@@ -1,0 +1,61 @@
+/**
+ * API Keys Migration
+ * Sets up initial key status for existing OpenRouter keys
+ */
+
+import { getSetting, saveSetting, getOpenRouterKey, storeOpenRouterKey } from '../core/db.js';
+import { getKeyStatus, KEY_STATUS } from './provider-settings-service.js';
+import { logger } from '../utils/logger.js';
+
+const MIGRATION_FLAG = 'llm_keys_migrated_v1';
+
+/**
+ * Run migration if needed
+ * Sets initial key status for existing OpenRouter keys
+ * Migrates legacy localStorage keys to IndexedDB
+ */
+export async function migrateApiKeys() {
+  const migrated = await getSetting(MIGRATION_FLAG);
+  if (migrated) {
+    return; // Already migrated
+  }
+
+  logger.info('Migrating API keys...');
+
+  try {
+    // Check for existing OpenRouter key (uses existing db.js mechanism)
+    const existingKey = await getOpenRouterKey();
+
+    if (existingKey) {
+      // Check if status already set
+      const status = await getKeyStatus('openrouter');
+
+      if (status === KEY_STATUS.NOT_SET) {
+        // Set initial status - mark as valid since it was working
+        // (User can revalidate if needed)
+        await saveSetting('llm_key_status_openrouter', KEY_STATUS.VALID);
+        logger.info('OpenRouter key status initialized');
+      }
+    }
+
+    // Check localStorage for legacy keys (from very old versions)
+    if (typeof localStorage !== 'undefined') {
+      const legacyKey = localStorage.getItem('openrouter_api_key');
+      if (legacyKey && !existingKey) {
+        // Import legacy key to IndexedDB
+        await storeOpenRouterKey(legacyKey);
+        await saveSetting('llm_key_status_openrouter', KEY_STATUS.VALID);
+        localStorage.removeItem('openrouter_api_key');
+        logger.info('Legacy OpenRouter key migrated from localStorage');
+      }
+    }
+
+    // Mark migration complete
+    await saveSetting(MIGRATION_FLAG, true);
+
+    logger.info('API key migration complete');
+  } catch (error) {
+    logger.error('API key migration failed:', error);
+    // Don't fail app startup - user can re-add key manually
+  }
+}

--- a/src/services/api-keys-migration.test.js
+++ b/src/services/api-keys-migration.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { migrateApiKeys } from './api-keys-migration.js';
+
+// Mock the db module
+vi.mock('../core/db.js', () => ({
+  getSetting: vi.fn(),
+  saveSetting: vi.fn(),
+  getOpenRouterKey: vi.fn(),
+  storeOpenRouterKey: vi.fn(),
+}));
+
+// Mock the provider-settings-service
+vi.mock('./provider-settings-service.js', () => ({
+  getKeyStatus: vi.fn(),
+  KEY_STATUS: {
+    NOT_SET: 'not_set',
+    VALIDATING: 'validating',
+    VALID: 'valid',
+    INVALID: 'invalid',
+  },
+}));
+
+// Mock the logger
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { getSetting, saveSetting, getOpenRouterKey, storeOpenRouterKey } from '../core/db.js';
+import { getKeyStatus, KEY_STATUS } from './provider-settings-service.js';
+import { logger } from '../utils/logger.js';
+
+describe('API Keys Migration', () => {
+  let originalLocalStorage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Save original localStorage
+    originalLocalStorage = global.localStorage;
+    // Create mock localStorage
+    global.localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    // Restore original localStorage
+    global.localStorage = originalLocalStorage;
+  });
+
+  describe('migrateApiKeys', () => {
+    it('should skip if already migrated', async () => {
+      getSetting.mockResolvedValue(true); // Already migrated
+
+      await migrateApiKeys();
+
+      expect(getSetting).toHaveBeenCalledWith('llm_keys_migrated_v1');
+      expect(getOpenRouterKey).not.toHaveBeenCalled();
+    });
+
+    it('should initialize status for existing OpenRouter key', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockResolvedValue('sk-or-v1-existingkey');
+      getKeyStatus.mockResolvedValue(KEY_STATUS.NOT_SET);
+      saveSetting.mockResolvedValue();
+
+      await migrateApiKeys();
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALID);
+      expect(saveSetting).toHaveBeenCalledWith('llm_keys_migrated_v1', true);
+      expect(logger.info).toHaveBeenCalledWith('OpenRouter key status initialized');
+    });
+
+    it('should not overwrite existing status', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockResolvedValue('sk-or-v1-existingkey');
+      getKeyStatus.mockResolvedValue(KEY_STATUS.VALID); // Already has status
+      saveSetting.mockResolvedValue();
+
+      await migrateApiKeys();
+
+      // Should not set status again
+      expect(saveSetting).not.toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALID);
+      // But should mark migration complete
+      expect(saveSetting).toHaveBeenCalledWith('llm_keys_migrated_v1', true);
+    });
+
+    it('should migrate legacy localStorage key', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockResolvedValue(null); // No key in IndexedDB
+      global.localStorage.getItem.mockReturnValue('sk-or-v1-legacykey');
+      storeOpenRouterKey.mockResolvedValue();
+      saveSetting.mockResolvedValue();
+
+      await migrateApiKeys();
+
+      expect(storeOpenRouterKey).toHaveBeenCalledWith('sk-or-v1-legacykey');
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALID);
+      expect(global.localStorage.removeItem).toHaveBeenCalledWith('openrouter_api_key');
+      expect(logger.info).toHaveBeenCalledWith('Legacy OpenRouter key migrated from localStorage');
+    });
+
+    it('should not migrate localStorage key if IndexedDB key exists', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockResolvedValue('sk-or-v1-existingkey'); // Key in IndexedDB
+      getKeyStatus.mockResolvedValue(KEY_STATUS.NOT_SET);
+      global.localStorage.getItem.mockReturnValue('sk-or-v1-legacykey'); // Also in localStorage
+      saveSetting.mockResolvedValue();
+
+      await migrateApiKeys();
+
+      // Should not store from localStorage
+      expect(storeOpenRouterKey).not.toHaveBeenCalled();
+      // Should not remove from localStorage
+      expect(global.localStorage.removeItem).not.toHaveBeenCalled();
+    });
+
+    it('should handle migration errors gracefully', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockRejectedValue(new Error('Database error'));
+
+      // Should not throw
+      await expect(migrateApiKeys()).resolves.not.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith('API key migration failed:', expect.any(Error));
+    });
+
+    it('should complete migration even with no keys', async () => {
+      getSetting.mockResolvedValue(null); // Not migrated yet
+      getOpenRouterKey.mockResolvedValue(null); // No key
+      global.localStorage.getItem.mockReturnValue(null); // No legacy key
+      saveSetting.mockResolvedValue();
+
+      await migrateApiKeys();
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_keys_migrated_v1', true);
+      expect(logger.info).toHaveBeenCalledWith('API key migration complete');
+    });
+  });
+});

--- a/src/services/provider-settings-service.js
+++ b/src/services/provider-settings-service.js
@@ -4,11 +4,24 @@
  */
 
 import { getSetting, saveSetting, getOpenRouterKey } from '../core/db.js';
+import { getProvider, validateKeyFormat, getAllProviders } from '../api/providers-config.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Key validation status enum
+ */
+export const KEY_STATUS = {
+  NOT_SET: 'not_set',
+  VALIDATING: 'validating',
+  VALID: 'valid',
+  INVALID: 'invalid',
+};
 
 const SETTINGS_KEYS = {
   ACTIVE_PROVIDER: 'llm_active_provider',
   ACTIVE_MODEL: 'llm_active_model',
   PROVIDER_KEY_PREFIX: 'llm_key_',
+  KEY_STATUS_PREFIX: 'llm_key_status_',
 };
 
 const DEFAULT_PROVIDER = 'openrouter';
@@ -122,4 +135,140 @@ export async function getConfiguredProviders() {
   }
 
   return configured;
+}
+
+// =============================================================================
+// Key Status and Validation (Phase 3)
+// =============================================================================
+
+/**
+ * Get key status for a provider
+ * @param {string} providerId - Provider ID
+ * @returns {Promise<string>} Key status (NOT_SET, VALIDATING, VALID, INVALID)
+ */
+export async function getKeyStatus(providerId) {
+  const status = await getSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId);
+  return status || KEY_STATUS.NOT_SET;
+}
+
+/**
+ * Set key status (internal helper)
+ * @param {string} providerId - Provider ID
+ * @param {string} status - Status to set
+ */
+async function setKeyStatus(providerId, status) {
+  await saveSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId, status);
+}
+
+/**
+ * Get masked key for display (e.g., "sk-12...cdef")
+ * @param {string} apiKey - Full API key
+ * @returns {string} Masked key for display
+ */
+export function getMaskedKey(apiKey) {
+  if (!apiKey || apiKey.length < 8) return '***';
+  const prefix = apiKey.substring(0, 5);
+  const suffix = apiKey.substring(apiKey.length - 4);
+  return `${prefix}...${suffix}`;
+}
+
+/**
+ * Save API key with format validation and async validation trigger
+ * Enhanced version of setProviderKey with validation
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key to save
+ * @returns {Promise<{status: string}>} Result with initial status
+ */
+export async function saveProviderKeyWithValidation(providerId, apiKey) {
+  const provider = getProvider(providerId);
+  if (!provider) {
+    throw new Error(`Unknown provider: ${providerId}`);
+  }
+
+  // Format validation (sync)
+  if (!validateKeyFormat(providerId, apiKey)) {
+    throw new Error(
+      `Invalid key format. ${provider.name} keys should start with '${provider.keyPrefix}'`
+    );
+  }
+
+  // Save key using existing function
+  await setProviderKey(providerId, apiKey);
+
+  // Set status to validating
+  await setKeyStatus(providerId, KEY_STATUS.VALIDATING);
+
+  // Trigger async validation (fire and forget)
+  validateKeyAsync(providerId, apiKey);
+
+  return { status: KEY_STATUS.VALIDATING };
+}
+
+/**
+ * Remove API key and clear status
+ * @param {string} providerId - Provider ID
+ */
+export async function removeProviderKeyWithStatus(providerId) {
+  await removeProviderKey(providerId);
+  await saveSetting(SETTINGS_KEYS.KEY_STATUS_PREFIX + providerId, null);
+}
+
+/**
+ * Get all provider statuses for UI display
+ * @returns {Promise<object>} Map of provider ID to status info
+ */
+export async function getAllProviderStatuses() {
+  const providers = getAllProviders();
+  const statuses = {};
+
+  for (const provider of providers) {
+    const key = await getProviderKey(provider.id);
+    const status = await getKeyStatus(provider.id);
+
+    statuses[provider.id] = {
+      hasKey: !!key,
+      maskedKey: key ? getMaskedKey(key) : null,
+      status: key ? status : KEY_STATUS.NOT_SET,
+    };
+  }
+
+  return statuses;
+}
+
+/**
+ * Re-validate a key (manual trigger from UI)
+ * @param {string} providerId - Provider ID
+ */
+export async function revalidateKey(providerId) {
+  const apiKey = await getProviderKey(providerId);
+  if (!apiKey) {
+    throw new Error('No key configured');
+  }
+
+  await setKeyStatus(providerId, KEY_STATUS.VALIDATING);
+  validateKeyAsync(providerId, apiKey);
+}
+
+// =============================================================================
+// Async Key Validation (Phase 3.2 - placeholder, implemented in next subtask)
+// =============================================================================
+
+/**
+ * Async validation - makes test call to provider
+ * Called after key is saved, updates status when complete
+ * @param {string} providerId - Provider ID
+ * @param {string} _apiKey - API key to validate (unused in placeholder, used in 3.2)
+ */
+async function validateKeyAsync(providerId, _apiKey) {
+  // Placeholder - will be implemented in Subtask 3.2
+  // For now, just mark as valid after a delay to simulate async behavior
+  try {
+    logger.debug(`Validating ${providerId} key...`);
+    // Actual implementation in 3.2 will call testProviderKey() with _apiKey
+    await setKeyStatus(providerId, KEY_STATUS.VALID);
+    logger.info(`${providerId} key marked as valid (full validation in 3.2)`);
+  } catch (error) {
+    logger.error(`${providerId} key validation error:`, error);
+    await setKeyStatus(providerId, KEY_STATUS.INVALID);
+  }
 }

--- a/src/services/provider-settings-service.js
+++ b/src/services/provider-settings-service.js
@@ -4,7 +4,12 @@
  */
 
 import { getSetting, saveSetting, getOpenRouterKey } from '../core/db.js';
-import { getProvider, validateKeyFormat, getAllProviders } from '../api/providers-config.js';
+import {
+  getProvider,
+  validateKeyFormat,
+  getAllProviders,
+  supportsCors,
+} from '../api/providers-config.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -250,25 +255,93 @@ export async function revalidateKey(providerId) {
 }
 
 // =============================================================================
-// Async Key Validation (Phase 3.2 - placeholder, implemented in next subtask)
+// Async Key Validation (Phase 3.2)
 // =============================================================================
 
 /**
  * Async validation - makes test call to provider
  * Called after key is saved, updates status when complete
  * @param {string} providerId - Provider ID
- * @param {string} _apiKey - API key to validate (unused in placeholder, used in 3.2)
+ * @param {string} apiKey - API key to validate
  */
-async function validateKeyAsync(providerId, _apiKey) {
-  // Placeholder - will be implemented in Subtask 3.2
-  // For now, just mark as valid after a delay to simulate async behavior
+async function validateKeyAsync(providerId, apiKey) {
   try {
     logger.debug(`Validating ${providerId} key...`);
-    // Actual implementation in 3.2 will call testProviderKey() with _apiKey
-    await setKeyStatus(providerId, KEY_STATUS.VALID);
-    logger.info(`${providerId} key marked as valid (full validation in 3.2)`);
+
+    const isValid = await testProviderKey(providerId, apiKey);
+
+    if (isValid) {
+      await setKeyStatus(providerId, KEY_STATUS.VALID);
+      logger.info(`${providerId} key validated successfully`);
+    } else {
+      await setKeyStatus(providerId, KEY_STATUS.INVALID);
+      logger.warn(`${providerId} key validation failed`);
+    }
   } catch (error) {
     logger.error(`${providerId} key validation error:`, error);
     await setKeyStatus(providerId, KEY_STATUS.INVALID);
+  }
+}
+
+/**
+ * Test provider key with minimal request
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key to test
+ * @returns {Promise<boolean>} True if key is valid
+ */
+async function testProviderKey(providerId, apiKey) {
+  if (supportsCors(providerId)) {
+    // OpenRouter - direct test via auth endpoint
+    return await testOpenRouterKey(apiKey);
+  } else {
+    // Other providers - test via proxy with minimal request
+    return await testViaProxy(providerId, apiKey);
+  }
+}
+
+/**
+ * Test OpenRouter key directly (CORS supported)
+ * @param {string} apiKey - OpenRouter API key
+ * @returns {Promise<boolean>} True if key is valid
+ */
+async function testOpenRouterKey(apiKey) {
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/auth/key', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    return response.ok;
+  } catch (error) {
+    logger.debug('OpenRouter key test failed:', error);
+    return false;
+  }
+}
+
+/**
+ * Test other provider keys via backend proxy
+ * @param {string} providerId - Provider ID
+ * @param {string} apiKey - API key to test
+ * @returns {Promise<boolean>} True if key is valid
+ */
+async function testViaProxy(providerId, apiKey) {
+  try {
+    const provider = getProvider(providerId);
+    const response = await fetch('https://saberloop.com/llm/completion.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: providerId,
+        api_key: apiKey,
+        model: provider.defaultModel,
+        messages: [{ role: 'user', content: 'Hi' }],
+        options: { max_tokens: 5 },
+      }),
+    });
+    return response.ok;
+  } catch (error) {
+    logger.debug(`${providerId} key test via proxy failed:`, error);
+    return false;
   }
 }

--- a/src/services/provider-settings-service.test.js
+++ b/src/services/provider-settings-service.test.js
@@ -9,6 +9,14 @@ import {
   removeProviderKey,
   hasProviderKey,
   getConfiguredProviders,
+  // Phase 3 exports
+  KEY_STATUS,
+  getKeyStatus,
+  getMaskedKey,
+  saveProviderKeyWithValidation,
+  removeProviderKeyWithStatus,
+  getAllProviderStatuses,
+  revalidateKey,
 } from './provider-settings-service.js';
 
 // Mock the db module
@@ -18,6 +26,48 @@ vi.mock('../core/db.js', () => ({
   getOpenRouterKey: vi.fn(),
   storeOpenRouterKey: vi.fn(),
   removeOpenRouterKey: vi.fn(),
+}));
+
+// Mock the logger
+vi.mock('../utils/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock providers-config
+vi.mock('../api/providers-config.js', () => ({
+  getProvider: vi.fn((id) => {
+    const providers = {
+      openrouter: { id: 'openrouter', name: 'OpenRouter', keyPrefix: 'sk-or-' },
+      openai: { id: 'openai', name: 'OpenAI', keyPrefix: 'sk-' },
+      anthropic: { id: 'anthropic', name: 'Anthropic', keyPrefix: 'sk-ant-' },
+      google: { id: 'google', name: 'Google AI', keyPrefix: 'AIza' },
+      xai: { id: 'xai', name: 'xAI', keyPrefix: 'xai-' },
+    };
+    return providers[id] || null;
+  }),
+  validateKeyFormat: vi.fn((providerId, key) => {
+    const prefixes = {
+      openrouter: 'sk-or-',
+      openai: 'sk-',
+      anthropic: 'sk-ant-',
+      google: 'AIza',
+      xai: 'xai-',
+    };
+    return key.startsWith(prefixes[providerId] || '');
+  }),
+  getAllProviders: vi.fn(() => [
+    { id: 'openrouter', name: 'OpenRouter' },
+    { id: 'openai', name: 'OpenAI' },
+    { id: 'anthropic', name: 'Anthropic' },
+    { id: 'google', name: 'Google AI' },
+    { id: 'xai', name: 'xAI' },
+  ]),
+  supportsCors: vi.fn((id) => id === 'openrouter'),
 }));
 
 import {
@@ -185,6 +235,217 @@ describe('Provider Settings Service', () => {
       expect(providers).toContain('google');
       expect(providers).not.toContain('anthropic');
       expect(providers).not.toContain('xai');
+    });
+  });
+
+  // ==========================================================================
+  // Phase 3: Key Status and Validation Tests
+  // ==========================================================================
+
+  describe('KEY_STATUS', () => {
+    it('should have all expected status values', () => {
+      expect(KEY_STATUS.NOT_SET).toBe('not_set');
+      expect(KEY_STATUS.VALIDATING).toBe('validating');
+      expect(KEY_STATUS.VALID).toBe('valid');
+      expect(KEY_STATUS.INVALID).toBe('invalid');
+    });
+  });
+
+  describe('getKeyStatus', () => {
+    it('should return NOT_SET when no status stored', async () => {
+      getSetting.mockResolvedValue(null);
+      const status = await getKeyStatus('openai');
+      expect(status).toBe(KEY_STATUS.NOT_SET);
+      expect(getSetting).toHaveBeenCalledWith('llm_key_status_openai');
+    });
+
+    it('should return stored status', async () => {
+      getSetting.mockResolvedValue(KEY_STATUS.VALID);
+      const status = await getKeyStatus('openai');
+      expect(status).toBe(KEY_STATUS.VALID);
+    });
+
+    it('should return VALIDATING status when stored', async () => {
+      getSetting.mockResolvedValue(KEY_STATUS.VALIDATING);
+      const status = await getKeyStatus('anthropic');
+      expect(status).toBe(KEY_STATUS.VALIDATING);
+    });
+
+    it('should return INVALID status when stored', async () => {
+      getSetting.mockResolvedValue(KEY_STATUS.INVALID);
+      const status = await getKeyStatus('google');
+      expect(status).toBe(KEY_STATUS.INVALID);
+    });
+  });
+
+  describe('getMaskedKey', () => {
+    it('should mask key correctly', () => {
+      expect(getMaskedKey('sk-1234567890abcdef')).toBe('sk-12...cdef');
+    });
+
+    it('should handle minimum length key', () => {
+      expect(getMaskedKey('12345678')).toBe('12345...5678');
+    });
+
+    it('should return *** for short keys', () => {
+      expect(getMaskedKey('short')).toBe('***');
+      expect(getMaskedKey('1234567')).toBe('***');
+    });
+
+    it('should handle null', () => {
+      expect(getMaskedKey(null)).toBe('***');
+    });
+
+    it('should handle undefined', () => {
+      expect(getMaskedKey(undefined)).toBe('***');
+    });
+
+    it('should handle empty string', () => {
+      expect(getMaskedKey('')).toBe('***');
+    });
+
+    it('should mask OpenAI key correctly', () => {
+      expect(getMaskedKey('sk-proj-abc123xyz789')).toBe('sk-pr...z789');
+    });
+
+    it('should mask Anthropic key correctly', () => {
+      expect(getMaskedKey('sk-ant-api03-abcdefghij')).toBe('sk-an...ghij');
+    });
+  });
+
+  describe('saveProviderKeyWithValidation', () => {
+    it('should reject unknown provider', async () => {
+      await expect(saveProviderKeyWithValidation('unknown', 'key')).rejects.toThrow(
+        'Unknown provider: unknown'
+      );
+    });
+
+    it('should reject invalid key format', async () => {
+      await expect(saveProviderKeyWithValidation('openai', 'invalid-key')).rejects.toThrow(
+        "Invalid key format. OpenAI keys should start with 'sk-'"
+      );
+    });
+
+    it('should save valid key and return validating status', async () => {
+      getSetting.mockResolvedValue(null);
+      saveSetting.mockResolvedValue();
+
+      const result = await saveProviderKeyWithValidation('openai', 'sk-validkey123456789');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_openai', 'sk-validkey123456789');
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', KEY_STATUS.VALIDATING);
+      expect(result.status).toBe(KEY_STATUS.VALIDATING);
+    });
+
+    it('should save OpenRouter key using storeOpenRouterKey', async () => {
+      getSetting.mockResolvedValue(null);
+      saveSetting.mockResolvedValue();
+      storeOpenRouterKey.mockResolvedValue();
+
+      const result = await saveProviderKeyWithValidation('openrouter', 'sk-or-v1-abc123');
+
+      expect(storeOpenRouterKey).toHaveBeenCalledWith('sk-or-v1-abc123');
+      expect(result.status).toBe(KEY_STATUS.VALIDATING);
+    });
+
+    it('should save Anthropic key correctly', async () => {
+      saveSetting.mockResolvedValue();
+
+      const result = await saveProviderKeyWithValidation('anthropic', 'sk-ant-api03-test');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_anthropic', 'sk-ant-api03-test');
+      expect(result.status).toBe(KEY_STATUS.VALIDATING);
+    });
+  });
+
+  describe('removeProviderKeyWithStatus', () => {
+    it('should remove key and clear status for regular provider', async () => {
+      saveSetting.mockResolvedValue();
+
+      await removeProviderKeyWithStatus('openai');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_openai', null);
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', null);
+    });
+
+    it('should remove OpenRouter key and clear status', async () => {
+      removeOpenRouterKey.mockResolvedValue();
+      saveSetting.mockResolvedValue();
+
+      await removeProviderKeyWithStatus('openrouter');
+
+      expect(removeOpenRouterKey).toHaveBeenCalled();
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', null);
+    });
+  });
+
+  describe('getAllProviderStatuses', () => {
+    it('should return status for all providers when no keys configured', async () => {
+      getOpenRouterKey.mockResolvedValue(null);
+      getSetting.mockResolvedValue(null);
+
+      const statuses = await getAllProviderStatuses();
+
+      expect(statuses).toHaveProperty('openrouter');
+      expect(statuses).toHaveProperty('openai');
+      expect(statuses).toHaveProperty('anthropic');
+      expect(statuses).toHaveProperty('google');
+      expect(statuses).toHaveProperty('xai');
+
+      // All should be NOT_SET with no key
+      expect(statuses.openai.hasKey).toBe(false);
+      expect(statuses.openai.maskedKey).toBeNull();
+      expect(statuses.openai.status).toBe(KEY_STATUS.NOT_SET);
+    });
+
+    it('should return correct status for configured providers', async () => {
+      getOpenRouterKey.mockResolvedValue('sk-or-v1-testkey123');
+      getSetting.mockImplementation((key) => {
+        if (key === 'llm_key_openai') return Promise.resolve('sk-openaikey123');
+        if (key === 'llm_key_status_openrouter') return Promise.resolve(KEY_STATUS.VALID);
+        if (key === 'llm_key_status_openai') return Promise.resolve(KEY_STATUS.VALIDATING);
+        return Promise.resolve(null);
+      });
+
+      const statuses = await getAllProviderStatuses();
+
+      expect(statuses.openrouter.hasKey).toBe(true);
+      expect(statuses.openrouter.maskedKey).toBe('sk-or...y123');
+      expect(statuses.openrouter.status).toBe(KEY_STATUS.VALID);
+
+      expect(statuses.openai.hasKey).toBe(true);
+      expect(statuses.openai.maskedKey).toBe('sk-op...y123');
+      expect(statuses.openai.status).toBe(KEY_STATUS.VALIDATING);
+    });
+  });
+
+  describe('revalidateKey', () => {
+    it('should throw when no key configured', async () => {
+      getSetting.mockResolvedValue(null);
+      getOpenRouterKey.mockResolvedValue(null);
+
+      await expect(revalidateKey('openai')).rejects.toThrow('No key configured');
+    });
+
+    it('should set status to validating and trigger validation', async () => {
+      getSetting.mockImplementation((key) => {
+        if (key === 'llm_key_openai') return Promise.resolve('sk-test123456');
+        return Promise.resolve(null);
+      });
+      saveSetting.mockResolvedValue();
+
+      await revalidateKey('openai');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', KEY_STATUS.VALIDATING);
+    });
+
+    it('should work for OpenRouter key', async () => {
+      getOpenRouterKey.mockResolvedValue('sk-or-v1-test123');
+      saveSetting.mockResolvedValue();
+
+      await revalidateKey('openrouter');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALIDATING);
     });
   });
 });

--- a/src/services/provider-settings-service.test.js
+++ b/src/services/provider-settings-service.test.js
@@ -42,11 +42,26 @@ vi.mock('../utils/logger.js', () => ({
 vi.mock('../api/providers-config.js', () => ({
   getProvider: vi.fn((id) => {
     const providers = {
-      openrouter: { id: 'openrouter', name: 'OpenRouter', keyPrefix: 'sk-or-' },
-      openai: { id: 'openai', name: 'OpenAI', keyPrefix: 'sk-' },
-      anthropic: { id: 'anthropic', name: 'Anthropic', keyPrefix: 'sk-ant-' },
-      google: { id: 'google', name: 'Google AI', keyPrefix: 'AIza' },
-      xai: { id: 'xai', name: 'xAI', keyPrefix: 'xai-' },
+      openrouter: {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        keyPrefix: 'sk-or-',
+        defaultModel: 'anthropic/claude-3.5-sonnet',
+      },
+      openai: { id: 'openai', name: 'OpenAI', keyPrefix: 'sk-', defaultModel: 'gpt-4o-mini' },
+      anthropic: {
+        id: 'anthropic',
+        name: 'Anthropic',
+        keyPrefix: 'sk-ant-',
+        defaultModel: 'claude-sonnet-4-20250514',
+      },
+      google: {
+        id: 'google',
+        name: 'Google AI',
+        keyPrefix: 'AIza',
+        defaultModel: 'gemini-2.5-flash',
+      },
+      xai: { id: 'xai', name: 'xAI', keyPrefix: 'xai-', defaultModel: 'grok-3-fast' },
     };
     return providers[id] || null;
   }),
@@ -446,6 +461,144 @@ describe('Provider Settings Service', () => {
       await revalidateKey('openrouter');
 
       expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALIDATING);
+    });
+  });
+
+  // ==========================================================================
+  // Phase 3.2: Async Key Validation Tests
+  // ==========================================================================
+
+  describe('Async Key Validation (integration)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should validate OpenRouter key directly and set VALID status', async () => {
+      storeOpenRouterKey.mockResolvedValue();
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: true });
+
+      await saveProviderKeyWithValidation('openrouter', 'sk-or-v1-validkey123');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should call OpenRouter auth endpoint directly
+      expect(global.fetch).toHaveBeenCalledWith('https://openrouter.ai/api/v1/auth/key', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer sk-or-v1-validkey123' },
+      });
+
+      // Status should be set to VALID after successful validation
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.VALID);
+    });
+
+    it('should set INVALID status when OpenRouter validation fails', async () => {
+      storeOpenRouterKey.mockResolvedValue();
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: false, status: 401 });
+
+      await saveProviderKeyWithValidation('openrouter', 'sk-or-v1-invalidkey');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Status should be set to INVALID after failed validation
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openrouter', KEY_STATUS.INVALID);
+    });
+
+    it('should validate OpenAI key via proxy and set VALID status', async () => {
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: true });
+
+      await saveProviderKeyWithValidation('openai', 'sk-validopenaikey123');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should call backend proxy (not direct API)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://saberloop.com/llm/completion.php',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      // Verify request body contains correct provider and key
+      const fetchCall = global.fetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.provider).toBe('openai');
+      expect(body.api_key).toBe('sk-validopenaikey123');
+      expect(body.model).toBe('gpt-4o-mini');
+      expect(body.options.max_tokens).toBe(5);
+
+      // Status should be set to VALID
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', KEY_STATUS.VALID);
+    });
+
+    it('should set INVALID status when proxy validation fails', async () => {
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: false, status: 401 });
+
+      await saveProviderKeyWithValidation('anthropic', 'sk-ant-invalidkey');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_anthropic', KEY_STATUS.INVALID);
+    });
+
+    it('should handle network errors gracefully', async () => {
+      saveSetting.mockResolvedValue();
+      global.fetch.mockRejectedValue(new Error('Network error'));
+
+      await saveProviderKeyWithValidation('openai', 'sk-validkey12345');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Should set INVALID on network error
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_openai', KEY_STATUS.INVALID);
+    });
+
+    it('should validate Google key via proxy', async () => {
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: true });
+
+      await saveProviderKeyWithValidation('google', 'AIzaValidGoogleKey123');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const fetchCall = global.fetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.provider).toBe('google');
+      expect(body.model).toBe('gemini-2.5-flash');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_google', KEY_STATUS.VALID);
+    });
+
+    it('should validate xAI key via proxy', async () => {
+      saveSetting.mockResolvedValue();
+      global.fetch.mockResolvedValue({ ok: true });
+
+      await saveProviderKeyWithValidation('xai', 'xai-validxaikey123');
+
+      // Wait for async validation to complete
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const fetchCall = global.fetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      expect(body.provider).toBe('xai');
+      expect(body.model).toBe('grok-3-fast');
+
+      expect(saveSetting).toHaveBeenCalledWith('llm_key_status_xai', KEY_STATUS.VALID);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `KEY_STATUS` enum for tracking API key validation states (NOT_SET, VALIDATING, VALID, INVALID)
- Implement async key validation (OpenRouter direct, others via proxy)
- Create API key migration for existing OpenRouter users
- Wire migration into app initialization

## What's New

### Key Status Tracking
- `getKeyStatus()` / `setKeyStatus()` - Track validation state per provider
- `getMaskedKey()` - Display keys securely (e.g., `sk-12...cdef`)
- `getAllProviderStatuses()` - Get all provider statuses for UI

### Async Key Validation
- `saveProviderKeyWithValidation()` - Save key with format + async validation
- OpenRouter: Direct validation via `/api/v1/auth/key`
- Other providers: Validation via backend proxy (minimal 5-token request)
- `revalidateKey()` - Manual re-validation trigger

### API Key Migration
- Sets initial `VALID` status for existing OpenRouter keys
- Migrates legacy localStorage keys to IndexedDB
- Runs once on app startup (tracked by flag)

## Test plan
- [x] All 1301 unit tests pass
- [x] All 179 E2E tests pass
- [x] Key status tracking works correctly
- [x] Async validation updates status appropriately
- [x] Migration runs successfully for existing users

## Files Changed
- `src/services/provider-settings-service.js` - Extended with 8 new functions
- `src/services/provider-settings-service.test.js` - Added 32 new tests
- `src/services/api-keys-migration.js` - New file
- `src/services/api-keys-migration.test.js` - New file (7 tests)
- `src/main.js` - Added migration call
- `docs/learning/epic11_llm_support/` - Updated docs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)